### PR TITLE
Fixed lib names in control.in

### DIFF
--- a/pkg/control.in
+++ b/pkg/control.in
@@ -6,5 +6,5 @@ Homepage: https://github.com/Riey/kime
 Section: utils
 Priority: optional
 Architecture: amd64
-Depends: libpango1.0-dev, libcairo2-dev, libgtk-3-dev, libglib2.0, libxcb1
+Depends: libpango-1.0-0, libcairo2, libgtk-3-0, libglib2.0-0, libxcb1
 


### PR DESCRIPTION
This fix works well on Ubuntu 20.04 LTS