### PR TITLE
Improve the configuration guide

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -85,7 +85,7 @@ export XMODIFIERS=@im=kime
 
 만약 X를 사용히사면 .xprofile에서 실행을 하실 수 있습니다.
 
-자세한 옵션은 [CONFIGURATION.md](docs/CONFIGURATION.md)를 참고하세요.
+자세한 옵션은 [CONFIGURATION.md](docs/CONFIGURATION.ko.md)를 참고하세요.
 
 ## 종속성 목록
 

--- a/docs/CONFIGURATION.ko.md
+++ b/docs/CONFIGURATION.ko.md
@@ -2,11 +2,15 @@
 
 [🇺🇸](CONFIGURATION.md), [🇰🇷](CONFIGURATION.ko.md)
 
-`/etc/kime/config.yaml`에 기본값으로 설정된 예시 파일을 볼 수 있습니다. [default_config.yaml](default_config.yaml)에서 온라인으로 볼 수도 있습니다. `~/.config/kime/config.yaml`이나 `$XDG_CONFIG_HOME/kime/config.yaml`에 `/etc/kime/config.yaml`의 내용을 복사해 보세요.
+`/etc/kime/config.yaml`에 기본값으로 설정된 파일이 있습니다. [default_config.yaml](default_config.yaml)에서 기본 설정 파일을 온라인으로 볼 수도 있습니다. `/etc/kime/config.yaml`에서 전역 설정을 수정하거나 `~/.config/kime/config.yaml`에 새 설정 파일을 만들 수 있습니다.
+
+[`$XDG_CONFIG_DIR`이나 `$XDG_CONFIG_HOME`][xdg] 환경 변수를 이용해 설정 파일의 위치를 바꿀 수도 있습니다. kime는 `$XDG_CONFIG_DIR/kime/config.yaml`과 `$XDG_CONFIG_HOME/kime/config.yaml`에 있는 설정 파일도 읽으려고 시도할 것입니다.
+
+[xdg]: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html#introduction
 
 ## layout
 
-키보드 자판을 설정합니다. `dubeolsik`(두벌식), `sebeolsik-390`(세벌식 390), `sebeolsik-391`(세벌식 391)이 기본으로 내장되어 있습니다. `$XDG_CONFIG_HOME/kime/layouts/`에 여기에 없는 키보드 자판을 YAML 파일로 직접 만들 수도 있습니다. [dubeolsik.yaml]을 참고해 보세요.
+키보드 자판을 설정합니다. `dubeolsik`(두벌식), `sebeolsik-390`(세벌식 390), `sebeolsik-391`(세벌식 391)이 기본으로 내장되어 있습니다. `$XDG_CONFIG_HOME/kime/layouts/`에 위 목록에 없는 키보드 자판을 YAML 파일로 직접 만들 수도 있습니다. [dubeolsik.yaml]을 참고해 보세요.
 
 [dubeolsik.yaml]: engine/core/data/dubeolsik.yaml
 

--- a/docs/CONFIGURATION.ko.md
+++ b/docs/CONFIGURATION.ko.md
@@ -1,6 +1,8 @@
 # 설정
 
-`/etc/kime/config.yaml`에 기본값으로 설정된 예시 파일이 있습니다. [default_config.yaml](default_config.yaml)에서 온라인으로 볼 수도 있습니다. `~/.config/kime/config.yaml`이나 `$XDG_CONFIG_HOME/kime/config.yaml`에 `/etc/kime/config.yaml`의 내용을 복사해 보세요.
+[🇺🇸](CONFIGURATION.md), [🇰🇷](CONFIGURATION.ko.md)
+
+`/etc/kime/config.yaml`에 기본값으로 설정된 예시 파일을 볼 수 있습니다. [default_config.yaml](default_config.yaml)에서 온라인으로 볼 수도 있습니다. `~/.config/kime/config.yaml`이나 `$XDG_CONFIG_HOME/kime/config.yaml`에 `/etc/kime/config.yaml`의 내용을 복사해 보세요.
 
 ## layout
 
@@ -55,8 +57,6 @@ XIM에서 쓸 편집창 글꼴과 크기입니다.
 
 쌍자음에 백스페이스를 누를 때 쌍자음을 분해시킵니다. (e.g. ㄲ -> ㄱ)
 
-#### default
-
 | 기본값 |`false`|
 |--------|-------|
 
@@ -67,15 +67,11 @@ XIM에서 쓸 편집창 글꼴과 크기입니다.
 ㅕ + ㅣ = ㅖ
 ```
 
-#### default
-
 | 기본값 |`false`|
 |--------|-------|
 
 
 ### decompose_jungseong_ssang
-
-#### default
 
 | 기본값 |`false`|
 |--------|-------|
@@ -87,14 +83,10 @@ XIM에서 쓸 편집창 글꼴과 크기입니다.
 ㅅ + ㅅ = ㅆ
 ```
 
-#### default
-
 | 기본값 |`false`|
 |--------|-------|
 
 ### decompose_jongseong_ssang
-
-#### default
 
 | 기본값 |`false`|
 |--------|-------|

--- a/docs/CONFIGURATION.ko.md
+++ b/docs/CONFIGURATION.ko.md
@@ -1,0 +1,100 @@
+# 설정
+
+`/etc/kime/config.yaml`에 기본값으로 설정된 예시 파일이 있습니다. [default_config.yaml](default_config.yaml)에서 온라인으로 볼 수도 있습니다. `~/.config/kime/config.yaml`이나 `$XDG_CONFIG_HOME/kime/config.yaml`에 `/etc/kime/config.yaml`의 내용을 복사해 보세요.
+
+## layout
+
+키보드 자판을 설정합니다. `dubeolsik`(두벌식), `sebeolsik-390`(세벌식 390), `sebeolsik-391`(세벌식 391)이 기본으로 내장되어 있습니다. `$XDG_CONFIG_HOME/kime/layouts/`에 여기에 없는 키보드 자판을 YAML 파일로 직접 만들 수도 있습니다. [dubeolsik.yaml]을 참고해 보세요.
+
+[dubeolsik.yaml]: engine/core/data/dubeolsik.yaml
+
+| 기본값 |`dubeolsik`|
+|--------|-----------|
+
+## esc_turn_off
+
+`ESC` 버튼을 누르면 영문 모드로 전환됩니다. vim을 쓸 때 유용한 기능입니다.
+
+| 기본값 |`true`|
+|--------|------|
+
+## hangul_keys
+
+한/영 모드를 전환하는 데 사용할 키들입니다.
+
+| 기본값 |`[Hangul, Muhenkan, AltR, Super-Space]`|
+|--------|---------------------------------------|
+
+## xim_preedit_font
+
+XIM에서 쓸 편집창 글꼴과 크기입니다.
+
+| 기본값 |`[D2Coding, 15.0]`|
+|--------|------------------|
+
+## compose
+
+자모 합성/분해 방식을 조정합니다.
+
+### compose_choseong_ssang
+
+같은 자음을 두 번 누를 때 쌍자음을 합성합니다.
+
+```
+ㄱ + ㄱ = ㄲ
+ㅅ + ㅅ = ㅆ
+ㄷ + ㄷ = ㄸ
+ㅂ + ㅂ = ㅃ
+ㅈ + ㅈ = ㅉ
+```
+
+| 기본값 |`true`|
+|--------|------|
+
+### decompose_choseong_ssang
+
+쌍자음에 백스페이스를 누를 때 쌍자음을 분해시킵니다. (e.g. ㄲ -> ㄱ)
+
+#### default
+
+| 기본값 |`false`|
+|--------|-------|
+
+### compose_jungseong_ssang
+
+```
+ㅑ + ㅣ = ㅒ
+ㅕ + ㅣ = ㅖ
+```
+
+#### default
+
+| 기본값 |`false`|
+|--------|-------|
+
+
+### decompose_jungseong_ssang
+
+#### default
+
+| 기본값 |`false`|
+|--------|-------|
+
+### compose_jongseong_ssang
+
+```
+ㄱ + ㄱ = ㄲ
+ㅅ + ㅅ = ㅆ
+```
+
+#### default
+
+| 기본값 |`false`|
+|--------|-------|
+
+### decompose_jongseong_ssang
+
+#### default
+
+| 기본값 |`false`|
+|--------|-------|

--- a/docs/CONFIGURATION.ko.md
+++ b/docs/CONFIGURATION.ko.md
@@ -2,7 +2,7 @@
 
 [🇺🇸](CONFIGURATION.md), [🇰🇷](CONFIGURATION.ko.md)
 
-`/etc/kime/config.yaml`에 기본값으로 설정된 파일이 있습니다. [default_config.yaml](default_config.yaml)에서 기본 설정 파일을 온라인으로 볼 수도 있습니다. `/etc/kime/config.yaml`에서 전역 설정을 수정하거나 `~/.config/kime/config.yaml`에 새 설정 파일을 만들 수 있습니다.
+`/etc/kime/config.yaml`에 기본값으로 설정된 파일이 있습니다. [default_config.yaml](default_config.yaml)에서 기본 설정 파일을 온라인으로 볼 수도 있습니다. `/etc/kime/config.yaml`에서 전역 설정을 수정하거나 `~/.config/kime/config.yaml`에 새 설정 파일을 만들어 보세요.
 
 [`$XDG_CONFIG_DIR`이나 `$XDG_CONFIG_HOME`][xdg] 환경 변수를 이용해 설정 파일의 위치를 바꿀 수도 있습니다. kime는 `$XDG_CONFIG_DIR/kime/config.yaml`과 `$XDG_CONFIG_HOME/kime/config.yaml`에 있는 설정 파일도 읽으려고 시도할 것입니다.
 

--- a/docs/CONFIGURATION.ko.md
+++ b/docs/CONFIGURATION.ko.md
@@ -12,7 +12,7 @@
 
 키보드 자판을 설정합니다. `dubeolsik`(두벌식), `sebeolsik-390`(세벌식 390), `sebeolsik-391`(세벌식 391)이 기본으로 내장되어 있습니다. `$XDG_CONFIG_HOME/kime/layouts/`에 위 목록에 없는 키보드 자판을 YAML 파일로 직접 만들 수도 있습니다. [dubeolsik.yaml]을 참고해 보세요.
 
-[dubeolsik.yaml]: engine/core/data/dubeolsik.yaml
+[dubeolsik.yaml]: ../engine/core/data/dubeolsik.yaml
 
 | 기본값 |`dubeolsik`|
 |--------|-----------|

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -13,7 +13,7 @@ You can also change the location of config file using [`$XDG_CONFIG_DIR` or
 ## layout
 
 Hangul layout name. "dubeolsik", "sebeolsik-390", and "sebeolsik-391" are
-available as default. Custom layout can be added by creating layout YAML filse
+available as default. Custom layout can be added by creating layout YAML files
 at `$XDG_CONFIG_HOME/kime/layouts/` directory. See [dubeolsik.yaml] for the
 structure of keyboard layout file.
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -20,7 +20,7 @@ available as default. Custom layout can be added by creating layout YAML files
 at `$XDG_CONFIG_HOME/kime/layouts/` directory. See [dubeolsik.yaml] for the
 structure of keyboard layout file.
 
-[dubeolsik.yaml]: engine/core/data/dubeolsik.yaml
+[dubeolsik.yaml]: ../engine/core/data/dubeolsik.yaml
 
 | default |`dubeolsik`|
 |---------|-----------|

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,4 +1,7 @@
 # Options
+
+[🇺🇸](CONFIGURATION.md), [🇰🇷](CONFIGURATION.ko.md)
+
 Default config file is located at `/etc/kime/config.yaml`. Check
 [default_config.yaml](default_config.yaml) to see the default configuration
 file. You edit `/etc/kime/config.yaml` or create a new config file at
@@ -19,33 +22,29 @@ structure of keyboard layout file.
 
 [dubeolsik.yaml]: engine/core/data/dubeolsik.yaml
 
-### default
-
-`dubeolsik`
+| default |`dubeolsik`|
+|---------|-----------|
 
 ## esc_turn_off
 
 Turn off hangul mode when esc is pressed especially for VIM users
 
-### default
-
-`true`
+| default |`true`|
+|---------|------|
 
 ## hangul_keys
 
 Keycodes for switch hangul mode
 
-### default
-
-`[Hangul, Muhenkan, AltR, Super-Space]`
+| default |`[Hangul, Muhenkan, AltR, Super-Space]`|
+|---------|---------------------------------------|
 
 ## xim_preedit_font
 
 Preedit window font name and size for XIM
 
-### default
-
-`[D2Coding, 15.0]`
+| default |`[D2Coding, 15.0]`|
+|---------|------------------|
 
 ## compose
 
@@ -61,17 +60,15 @@ Adjust compose, decompose jamo
 ㅈ + ㅈ = ㅉ
 ```
 
-#### default
-
-`true`
+| default |`true`|
+|---------|------|
 
 ### decompose_choseong_ssang
 
 Same as above but work on backspace(e.g. ㄲ -> ㄱ)
 
-#### default
-
-`false`
+| default |`false`|
+|---------|-------|
 
 ### compose_jungseong_ssang
 
@@ -80,16 +77,14 @@ Same as above but work on backspace(e.g. ㄲ -> ㄱ)
 ㅕ + ㅣ = ㅖ
 ```
 
-#### default
-
-`false`
+| default |`false`|
+|---------|-------|
 
 
 ### decompose_jungseong_ssang
 
-#### default
-
-`false`
+| default |`false`|
+|---------|-------|
 
 ### compose_jongseong_ssang
 
@@ -98,12 +93,10 @@ Same as above but work on backspace(e.g. ㄲ -> ㄱ)
 ㅅ + ㅅ = ㅆ
 ```
 
-#### default
-
-`false`
+| default |`false`|
+|---------|-------|
 
 ### decompose_jongseong_ssang
 
-#### default
-
-`false`
+| default |`false`|
+|---------|-------|


### PR DESCRIPTION
- Fix some typoes
- Add Korean translation(`CONFIGURATION.ko.md`)
- Make default value easier to read