### PR TITLE
Don't use country flag to represent languages

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -2,7 +2,7 @@
 
 한글 입력기
 
-[🇺🇸](./README.md), [🇰🇷](./README.ko.md)
+[English](./README.md), [한국어](./README.ko.md)
 
 [<img alt="discord" src="https://img.shields.io/discord/801107569505992705.svg?style=for-the-badge" height="25">](https://discord.gg/YPnEfZqC6y)
 [<img alt="build status" src="https://img.shields.io/github/workflow/status/Riey/kime/CI/master?style=for-the-badge" height="25">](https://github.com/Riey/kime/actions?query=workflow%3ACI)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Korean IME
 
-[🇺🇸](./README.md), [🇰🇷](./README.ko.md)
+[English](./README.md), [한국어](./README.ko.md)
 
 [<img alt="discord" src="https://img.shields.io/discord/801107569505992705.svg?style=for-the-badge" height="25">](https://discord.gg/YPnEfZqC6y)
 [<img alt="build status" src="https://img.shields.io/github/workflow/status/Riey/kime/CI/master?style=for-the-badge" height="25">](https://github.com/Riey/kime/actions?query=workflow%3ACI)


### PR DESCRIPTION
Using country flag for languages probably isn't good idea. Especially, English is chosen for official language by many countries, [like 50+ countries](https://en.wikipedia.org/wiki/List_of_territorial_entities_where_English_is_an_official_language), and that makes impossible to choose a country flag for English. Also Korean has a same problem (although it's name is **Korea**n), like China (조선족; based on 문화어) and Russia (고려인; based on 고려말). And there's many constructed languages that don't represent any countries by design. These examples show we can't match languages and countries one by one.

Related: #141