### PR TITLE
Implement KeyRepeat to the Wayland frontent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,16 +218,6 @@ version = "0.1.0"
 source = "git+https://github.com/Riey/ctext-rs#94b83abb5e7a23e55b134a2fd1cfded9d8f7912d"
 
 [[package]]
-name = "ctrlc"
-version = "3.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b57a92e9749e10f25a171adcebfafe72991d45e7ec2dcb853e8f83d9dafaeb08"
-dependencies = [
- "nix 0.18.0",
- "winapi",
-]
-
-[[package]]
 name = "daemonize"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -604,7 +594,6 @@ dependencies = [
 name = "kime-wayland"
 version = "0.1.0"
 dependencies = [
- "ctrlc",
  "kime-engine-cffi",
  "kime-version",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -599,6 +599,7 @@ dependencies = [
  "libc",
  "log",
  "mio",
+ "mio-timerfd",
  "pico-args",
  "simplelog",
  "wayland-client",
@@ -760,6 +761,16 @@ dependencies = [
  "miow",
  "ntapi",
  "winapi",
+]
+
+[[package]]
+name = "mio-timerfd"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61840339b339e86a6f728531091b7626d16da3256037152ac92c66b8801c365c"
+dependencies = [
+ "libc",
+ "mio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -598,6 +598,7 @@ dependencies = [
  "kime-version",
  "libc",
  "log",
+ "mio",
  "pico-args",
  "simplelog",
  "wayland-client",
@@ -749,6 +750,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
+name = "mio"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e50ae3f04d169fcc9bde0b547d1c205219b7157e07ded9c5aff03e0637cb3ed7"
+dependencies = [
+ "libc",
+ "log",
+ "miow",
+ "ntapi",
+ "winapi",
+]
+
+[[package]]
+name = "miow"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
+dependencies = [
+ "socket2",
+ "winapi",
+]
+
+[[package]]
 name = "nix"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -780,6 +804,15 @@ checksum = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
 dependencies = [
  "memchr",
  "version_check 0.1.5",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -1093,6 +1126,17 @@ name = "smallvec"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
+
+[[package]]
+name = "socket2"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "strsim"

--- a/src/frontends/wayland/Cargo.toml
+++ b/src/frontends/wayland/Cargo.toml
@@ -12,7 +12,6 @@ wayland-client = { version = "0.28.3" }
 zwp-input-method = { git = "https://github.com/Riey/zwp-input-method" }
 zwp-virtual-keyboard = "0.2.0"
 
-ctrlc = { version = "3.1.7", features = ["termination"] }
 libc = "0.2.82"
 log = "0.4.13"
 pico-args = "0.4.0"

--- a/src/frontends/wayland/Cargo.toml
+++ b/src/frontends/wayland/Cargo.toml
@@ -16,3 +16,4 @@ libc = "0.2.82"
 log = "0.4.13"
 pico-args = "0.4.0"
 simplelog = "0.9.0"
+mio = { version = "0.7.7", features = ["os-ext"] }

--- a/src/frontends/wayland/Cargo.toml
+++ b/src/frontends/wayland/Cargo.toml
@@ -17,3 +17,4 @@ log = "0.4.13"
 pico-args = "0.4.0"
 simplelog = "0.9.0"
 mio = { version = "0.7.7", features = ["os-ext"] }
+mio-timerfd = "0.2.0"

--- a/src/frontends/wayland/src/main.rs
+++ b/src/frontends/wayland/src/main.rs
@@ -138,7 +138,7 @@ impl KimeContext {
                 }
                 self.current_state = std::mem::take(&mut self.pending_state);
             }
-            ImEvent::TextChangeCause { .. } | ImEvent::SurroundingText { .. } | _ => {}
+            _ => {}
         }
     }
 

--- a/src/frontends/wayland/src/main.rs
+++ b/src/frontends/wayland/src/main.rs
@@ -461,9 +461,10 @@ fn main() {
             //
             // Reference:
             //   https://www.gnu.org/software/libc/manual/html_node/Interrupted-Primitives.html
-            if e.kind() != ErrorKind::Interrupted {
-                break Err(e);
+            if e.kind() == ErrorKind::Interrupted {
+                continue;
             }
+            break Err(e);
         }
 
         for event in &events {

--- a/src/frontends/wayland/src/main.rs
+++ b/src/frontends/wayland/src/main.rs
@@ -317,10 +317,15 @@ fn main() {
                     continue;
                 }
 
-                if err.kind() != std::io::ErrorKind::Interrupted {
-                    log::error!("IO Error: {}", err);
+                // Should retry on EINTR
+                //
+                // Reference:
+                //   https://www.gnu.org/software/libc/manual/html_node/Interrupted-Primitives.html
+                if err.kind() == std::io::ErrorKind::Interrupted {
+                    continue;
                 }
 
+                log::error!("IO Error: {}", err);
                 break;
             }
         }

--- a/src/frontends/wayland/src/main.rs
+++ b/src/frontends/wayland/src/main.rs
@@ -190,6 +190,7 @@ impl KimeContext {
                     kb.assign(filter.clone());
                     self.grab_kb = Some(kb);
                 } else if !self.current_state.deactivate && self.pending_state.deactivate {
+                    // Focus lost, reset states
                     if let Some(c) = self.engine.reset() {
                         self.commit_ch(c);
                         self.commit();
@@ -197,6 +198,8 @@ impl KimeContext {
                     if let Some(kb) = self.grab_kb.take() {
                         kb.release();
                     }
+                    self.timer.disarm().unwrap(); // TODO: Error handling
+                    self.repeat_state = None
                 }
                 self.current_state = std::mem::take(&mut self.pending_state);
             }

--- a/src/frontends/wayland/src/main.rs
+++ b/src/frontends/wayland/src/main.rs
@@ -325,7 +325,7 @@ impl KimeContext {
                 }
                 PressState::NotRepeatingYet { key, time } => {
                     // Start repeat
-                    log::info!("Start repeating {}", key);
+                    log::trace!("Start repeating {}", key);
                     let interval = &Duration::from_secs_f64(1.0 / info.rate as f64);
                     self.timer.set_timeout_interval(interval)?;
 
@@ -334,7 +334,7 @@ impl KimeContext {
                     (key, time)
                 }
                 PressState::Repeating { key, time } => {
-                    log::info!("Keep repeating {}", key);
+                    log::trace!("Keep repeating {}", key);
                     (*key, *time)
                 }
             };

--- a/src/frontends/wayland/src/main.rs
+++ b/src/frontends/wayland/src/main.rs
@@ -198,8 +198,6 @@ impl KimeContext {
                 } else {
                     self.vk.key(time, key, state as _);
                 }
-
-                // TODO: repeat key
             }
             KeyEvent::Modifiers {
                 mods_depressed,

--- a/src/frontends/wayland/src/main.rs
+++ b/src/frontends/wayland/src/main.rs
@@ -4,7 +4,6 @@ use wayland_client::{
     DispatchData, Display, Filter, GlobalManager, Main,
 };
 
-use std::sync::atomic::{AtomicBool, Ordering};
 use zwp_input_method::input_method_unstable_v2::{
     zwp_input_method_keyboard_grab_v2::{Event as KeyEvent, ZwpInputMethodKeyboardGrabV2},
     zwp_input_method_manager_v2::ZwpInputMethodManagerV2,
@@ -242,13 +241,6 @@ fn main() {
         return;
     }
 
-    static STOP: AtomicBool = AtomicBool::new(false);
-
-    ctrlc::set_handler(|| {
-        STOP.store(true, Ordering::Relaxed);
-    })
-    .expect("Set handler");
-
     let mut log_level = if cfg!(debug_assertions) {
         log::LevelFilter::Trace
     } else {
@@ -306,7 +298,7 @@ fn main() {
 
     log::info!("Server init success!");
 
-    while !STOP.load(Ordering::Relaxed) {
+    loop {
         // ignore unfiltered messages
         match event_queue.dispatch(&mut kime_ctx, |_, _, _| ()) {
             Ok(_) => {}

--- a/src/frontends/wayland/src/main.rs
+++ b/src/frontends/wayland/src/main.rs
@@ -160,6 +160,7 @@ impl KimeContext {
             KeyEvent::Key {
                 state, key, time, ..
             } => {
+                // NOTE: Never read `serial` of KeyEvent. You should rely on serial of KimeContext
                 if state == KeyState::Pressed {
                     let mut bypass = false;
                     let ret = self

--- a/src/frontends/wayland/src/main.rs
+++ b/src/frontends/wayland/src/main.rs
@@ -198,7 +198,7 @@ impl KimeContext {
                     if let Some(kb) = self.grab_kb.take() {
                         kb.release();
                     }
-                    self.timer.disarm().unwrap(); // TODO: Error handling
+                    self.timer.disarm().unwrap();
                     self.repeat_state = None
                 }
                 self.current_state = std::mem::take(&mut self.pending_state);
@@ -227,7 +227,7 @@ impl KimeContext {
                     if let Some((info, ref mut press_state)) = self.repeat_state {
                         if !press_state.is_pressing(key) {
                             let duration = Duration::from_millis(info.delay as u64);
-                            self.timer.set_timeout(&duration).unwrap(); // TODO: Error handling
+                            self.timer.set_timeout(&duration).unwrap();
                             *press_state = PressState::NotRepeatingYet { key, time };
                         }
                     }
@@ -274,7 +274,7 @@ impl KimeContext {
                     // If user released the last pressed key, clear the timer and state
                     if let Some((.., ref mut press_state)) = self.repeat_state {
                         if press_state.is_pressing(key) {
-                            self.timer.disarm().unwrap(); // TODO: Error handling
+                            self.timer.disarm().unwrap();
                             *press_state = PressState::NotPressing;
                         }
                     }

--- a/src/frontends/wayland/src/main.rs
+++ b/src/frontends/wayland/src/main.rs
@@ -270,7 +270,7 @@ fn main() {
 
     let display = Display::connect_to_env().expect("Failed to connect wayland display");
     let mut event_queue = display.create_event_queue();
-    let attached_display = (*display).clone().attach(event_queue.token());
+    let attached_display = display.attach(event_queue.token());
     let globals = GlobalManager::new(&attached_display);
 
     event_queue.sync_roundtrip(&mut (), |_, _, _| ()).unwrap();

--- a/src/frontends/wayland/src/main.rs
+++ b/src/frontends/wayland/src/main.rs
@@ -344,7 +344,6 @@ impl KimeContext {
                 // initially pressed, or the time of this KeyEvent
                 time,
                 key,
-                // NOTE: KeyState::Repeat is not defined in wayland_client crate.
                 state: KeyState::Pressed,
             };
             self.serial += 1;


### PR DESCRIPTION
TODOs

- [x] ~~"Press <kbd>a</kbd> → Press <kbd>b</kbd> → Release <kbd>b</kbd> → Release <kbd>a</kbd>" falls into inconsistent state~~ It was false warning, fixed by f9d33c5
- [x] 키를 떼기 전까지는 입력한 키가 화면에 안나타나는 현상이 발생함 → Fixed by 62c363f
- [x] kime-wayland가 켜지면 GTK앱에선 한글입력이 비정상적으로 변함
  1. wayland앱에서 KeyRepeat시작
  2. KeyRepeat인 상태로 포커스를 GTK앱이나 기타등 밖으로 탈출함
  3. 파이어폭스에 repeat글자가 연타되고, 그거랑 GTK_IM의 입력이 같이 들어옴
- [x] ~~Handle SIGINT gracefully~~ → #174 

Closes #139 