### PR TITLE
wayland: Don't bother to commit preedit text on deactivate

### DIFF
--- a/src/frontends/wayland/src/main.rs
+++ b/src/frontends/wayland/src/main.rs
@@ -191,13 +191,7 @@ impl KimeContext {
                     self.grab_kb = Some(kb);
                 } else if !self.current_state.deactivate && self.pending_state.deactivate {
                     // Focus lost, reset states
-                    match self.engine.reset() {
-                        '\0' => {}
-                        c => {
-                            self.commit_ch(c);
-                            self.commit();
-                        }
-                    }
+                    self.engine.reset();
                     if let Some(kb) = self.grab_kb.take() {
                         kb.release();
                     }


### PR DESCRIPTION
With input-method-unstable-v2, it's impossible to finish preedit texts before deactivate.

> I think this is a bug in IME. Focus changes deactivates the input-method and I think there is no way to know it is going to be deactivated in advance. Which means IME does not have chance to commit string to old text-input. Also, by the protocol, there is no way to distinguish the text-input behind. With these, I think IME should reset their internal states (for example, to-be-committed string) on deactivate. This is what my wlchewing does, and so it does not have this bug.
>
> @xdavidwu

##### Reference
- https://github.com/swaywm/sway/pull/4932#issuecomment-774113129