### PR TITLE
wayland: Don't forget RepeatInfo on deactivate

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Handle disabled key repeat properly by **[@simnalamburt]** ([#188](https://github.com/Riey/kime/issues/188))
 * Fix unwanted key repeat bug on wayland by **[@simnalamburt]** ([#206](https://github.com/Riey/kime/issues/206))
 * Fix preedit string sended to wrong client by **[@simnalamburt]** ([#205](https://github.com/Riey/kime/issues/205))
+* Fix the key repeat regression by **[@simnalamburt]** ([#215](https://github.com/Riey/kime/issues/215))
 
 ## 1.0.0-pre2
 


### PR DESCRIPTION
Fixes the regression regarding key repeat introduced by #214

> IME를 껐다킨 직후엔 잘되는데 파이어폭스를 켜고 alt+1 alt+2 alt+1 로 탭을 바꿨다돌아오면 ㅋㅋㅋㅋ가 안되기 시작함