### PR TITLE
Make keycode 130 to Hangul

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 * Support word commit [#288](https://github.com/Riey/kime/issues/288)
 * Make qt preedit string have underline style
-* Make keycode 130 to Hangul
+* Make keycode 130 to Hangul [#291](https://github.com/Riey/kime/issues/291)
 
 ## 1.1.1
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 * Support word commit [#288](https://github.com/Riey/kime/issues/288)
 * Make qt preedit string have underline style
+* Make keycode 130 to Hangul
 
 ## 1.1.1
 

--- a/src/engine/core/src/keycode.rs
+++ b/src/engine/core/src/keycode.rs
@@ -156,7 +156,7 @@ impl KeyCode {
             100 => Some(Self::Henkan),
             102 => Some(Self::Muhenkan),
             108 => Some(Self::AltR),
-            122 => Some(Self::Hangul),
+            122 | 130 => Some(Self::Hangul),
             _ => None,
         }
     }


### PR DESCRIPTION
## Summary

Fix #291

## Note

Maybe it's better to use keysym because many users don't familiar with scancode mapping

## Checklist

- [x] I have documented my changes properly to adequate places
- [x] I have updated the docs/CHANGELOG.md
