### PR TITLE
Fix preedit string disapear when press hotkey

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Improve
 
 * Fix kime-check fail [#307](https://github.com/Riey/kime/issues/307)
+* Fix preedit string disapear when press hotkey [#310](https://github.com/Riey/kime/issues/310)
 
 ## 1.1.3
 

--- a/src/engine/core/src/lib.rs
+++ b/src/engine/core/src/lib.rs
@@ -116,7 +116,7 @@ impl InputEngine {
 
             let mut ret = match hotkey.result() {
                 HotkeyResult::Bypass => self.bypass(),
-                HotkeyResult::Consume => InputResult::CONSUMED,
+                HotkeyResult::Consume => InputResult::CONSUMED | self.state.preedit_result(),
             };
 
             if self.enable_hangul != first {

--- a/src/engine/core/tests/dubeolsik.rs
+++ b/src/engine/core/tests/dubeolsik.rs
@@ -66,6 +66,12 @@ fn word_hello() {
     ])
 }
 
+// issue #310
+#[test]
+fn hangul_change_preedit() {
+    test_input(&[(Key::normal(R), "ㄱ", ""), (Key::normal(Hangul), "ㄱ", "")]);
+}
+
 #[test]
 fn esc() {
     test_input(&[


### PR DESCRIPTION
## Summary

Fix #310

## Checklist

- [x] I have documented my changes properly to adequate places
- [x] I have updated the docs/CHANGELOG.md
