### PR TITLE
Make character typing order strict `ㅏ + ㄱ = ㅏㄱ`

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 * Fix kime-check fail [#307](https://github.com/Riey/kime/issues/307)
 * Fix preedit string disapear when press hotkey [#310](https://github.com/Riey/kime/issues/310)
+* Make character typing order strict `ㅏ + ㄱ = ㅏㄱ`
 
 ## 1.1.3
 

--- a/src/engine/core/src/state.rs
+++ b/src/engine/core/src/state.rs
@@ -301,19 +301,24 @@ impl CharacterState {
                 })
             } else {
                 match prev_cho.try_add(cho, config) {
-                    Some(new) => {
+                    Some(new) if self.jung.is_none() => {
                         self.cho = Some(new);
                         CharacterResult::Consume
                     }
-                    None => CharacterResult::NewCharacter(Self {
+                    _ => CharacterResult::NewCharacter(Self {
                         cho: Some(cho),
                         ..Default::default()
                     }),
                 }
             }
-        } else {
+        } else if self.jung.is_none() && self.jong.is_none() {
             self.cho = Some(cho);
             CharacterResult::Consume
+        } else {
+            CharacterResult::NewCharacter(Self {
+                cho: Some(cho),
+                ..Default::default()
+            })
         }
     }
 

--- a/src/engine/core/tests/dubeolsik.rs
+++ b/src/engine/core/tests/dubeolsik.rs
@@ -82,8 +82,8 @@ fn esc() {
 }
 
 #[test]
-fn issue_28() {
-    test_input(&[(Key::normal(K), "ㅏ", ""), (Key::normal(R), "가", "")])
+fn con_typing() {
+    test_input(&[(Key::normal(K), "ㅏ", ""), (Key::normal(R), "ㄱ", "ㅏ")])
 }
 
 #[test]

--- a/src/engine/core/tests/sebeolsik_390.rs
+++ b/src/engine/core/tests/sebeolsik_390.rs
@@ -71,8 +71,8 @@ fn compose_choseong_ssang() {
 fn switch_next() {
     test_input(&[
         (Key::normal(S), "ㄴ", ""),
-        (Key::normal(F), "ㅏ", "ㄴ"),
-        (Key::normal(J), "아", ""),
+        (Key::normal(J), "ㅇ", "ㄴ"),
+        (Key::normal(F), "아", ""),
     ]);
 }
 

--- a/src/engine/core/tests/sebeolsik_391.rs
+++ b/src/engine/core/tests/sebeolsik_391.rs
@@ -59,9 +59,21 @@ fn hello() {
 fn switch_next() {
     test_input(&[
         (Key::normal(S), "ㄴ", ""),
-        (Key::normal(F), "ㅏ", "ㄴ"),
-        (Key::normal(J), "아", ""),
+        (Key::normal(J), "ㅇ", "ㄴ"),
+        (Key::normal(F), "아", ""),
     ]);
+}
+
+#[test]
+fn good() {
+    test_input(&[
+        (Key::normal(K), "ㄱ", ""),
+        (Key::normal(R), "개", ""),
+        (Key::normal(K), "ㄱ", "개"),
+        (Key::normal(K), "ㄲ", ""),
+        (Key::normal(B), "꾸", ""),
+        (Key::normal(W), "꿀", ""),
+    ])
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Make character typing order strict `ㅏ + ㄱ = ㅏㄱ`

## Checklist

- [x] I have documented my changes properly to adequate places
- [x] I have updated the docs/CHANGELOG.md
