### PR TITLE
Make InputMode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -612,12 +612,19 @@ version = "0.1.0"
 dependencies = [
  "enumset",
  "kime-engine-backend",
- "kime-engine-dict",
  "num-derive",
  "num-traits",
  "serde",
  "serde_yaml",
  "xdg",
+]
+
+[[package]]
+name = "kime-engine-backend-hanja"
+version = "0.1.0"
+dependencies = [
+ "kime-engine-backend",
+ "kime-engine-dict",
 ]
 
 [[package]]
@@ -662,9 +669,9 @@ dependencies = [
  "enumset",
  "kime-engine-backend",
  "kime-engine-backend-hangul",
+ "kime-engine-backend-hanja",
  "kime-engine-backend-latin",
  "kime-engine-backend-math",
- "kime-engine-dict",
  "kime-run-dir",
  "maplit",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
 
     "src/engine/backend",
     "src/engine/backends/hangul",
+    "src/engine/backends/hanja",
     "src/engine/backends/latin",
     "src/engine/backends/math",
 

--- a/src/engine/backend/src/lib.rs
+++ b/src/engine/backend/src/lib.rs
@@ -20,3 +20,23 @@ pub trait InputEngineBackend {
     /// Is have preedit
     fn has_preedit(&self) -> bool;
 }
+
+pub enum InputEngineModeResult<T> {
+    Continue(T),
+    Exit,
+}
+
+pub trait InputEngineMode {
+    /// Press key
+    /// # Return
+    /// `Ok(true)` means key has handled
+    fn press_key(&mut self, key: Key, commit_buf: &mut String) -> InputEngineModeResult<bool>;
+    /// Clear current preedit string this function may change commit string
+    fn clear_preedit(&mut self, commit_buf: &mut String) -> InputEngineModeResult<()>;
+    /// Clear engine state
+    fn reset(&mut self) -> InputEngineModeResult<()>;
+    /// Get preedit string
+    fn preedit_str(&self, buf: &mut String);
+    /// Is have preedit
+    fn has_preedit(&self) -> bool;
+}

--- a/src/engine/backends/hangul/Cargo.toml
+++ b/src/engine/backends/hangul/Cargo.toml
@@ -7,7 +7,6 @@ license = "GPL-3.0"
 
 [dependencies]
 kime-engine-backend = { path = "../../backend" }
-kime-engine-dict = { path = "../../dict" }
 enumset = "1.0.6"
 num-derive = "0.3.3"
 num-traits = "0.2.14"

--- a/src/engine/backends/hangul/src/state.rs
+++ b/src/engine/backends/hangul/src/state.rs
@@ -1,84 +1,9 @@
 use enumset::EnumSet;
-use kime_engine_backend::{Key, KeyCode};
 
 use crate::{
     characters::{Choseong, JongToCho, Jongseong, Jungseong, KeyValue},
     Addon,
 };
-
-#[derive(Debug, Clone)]
-pub struct HanjaState {
-    hanja_entires: &'static [(char, &'static str)],
-    hangul: char,
-    index: usize,
-}
-
-impl HanjaState {
-    pub fn new(hangul: char) -> Option<Self> {
-        Some(Self {
-            hanja_entires: kime_engine_dict::lookup(hangul)?,
-            index: 0,
-            hangul,
-        })
-    }
-
-    pub fn current_hanja(&self) -> char {
-        self.hanja_entires[self.index].0
-    }
-
-    fn try_index(&mut self, index: usize) {
-        self.index = index.min(self.hanja_entires.len() - 1);
-    }
-
-    pub fn press_key(&mut self, key: Key) -> bool {
-        match key.code {
-            KeyCode::Left => {
-                self.index = self
-                    .index
-                    .checked_sub(1)
-                    .unwrap_or(self.hanja_entires.len() - 1);
-                true
-            }
-            KeyCode::Right => {
-                self.try_index(self.index + 1);
-                true
-            }
-            KeyCode::One
-            | KeyCode::Two
-            | KeyCode::Three
-            | KeyCode::Four
-            | KeyCode::Five
-            | KeyCode::Six
-            | KeyCode::Seven
-            | KeyCode::Eight
-            | KeyCode::Nine => {
-                self.try_index(key.code as usize - KeyCode::One as usize);
-                true
-            }
-            _ => false,
-        }
-    }
-
-    pub fn preedit_str(&self, buf: &mut String) {
-        let current_hanja = &self.hanja_entires[self.index];
-
-        for (prev_hanja, _) in self.hanja_entires[..self.index].iter() {
-            buf.push(*prev_hanja);
-        }
-
-        buf.push('/');
-        buf.push(current_hanja.0);
-        buf.push('(');
-        buf.push_str(current_hanja.1);
-        buf.push(')');
-
-        if let Some(next_hanjas) = self.hanja_entires.get(self.index + 1..) {
-            for (next_hanja, _) in next_hanjas {
-                buf.push(*next_hanja);
-            }
-        }
-    }
-}
 
 /// 한글 입력 오토마타
 #[derive(Debug, Clone)]

--- a/src/engine/backends/hanja/Cargo.toml
+++ b/src/engine/backends/hanja/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "kime-engine-backend-hanja"
+version = "0.1.0"
+authors = ["Riey <creeper844@gmail.com>"]
+edition = "2018"
+license = "GPL-3.0"
+
+[dependencies]
+kime-engine-backend = { path = "../../backend" }
+kime-engine-dict = { path = "../../dict" }

--- a/src/engine/backends/hanja/src/lib.rs
+++ b/src/engine/backends/hanja/src/lib.rs
@@ -1,0 +1,119 @@
+use kime_engine_backend::{
+    InputEngineMode,
+    InputEngineModeResult::{self, Continue, Exit},
+    Key, KeyCode,
+};
+
+#[derive(Debug, Clone)]
+pub struct HanjaMode {
+    hanja_entires: &'static [(char, &'static str)],
+    index: usize,
+}
+
+impl Default for HanjaMode {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl HanjaMode {
+    pub fn new() -> Self {
+        Self {
+            hanja_entires: &[],
+            index: 0,
+        }
+    }
+
+    pub fn set_key(&mut self, key: char) -> bool {
+        if let Some(entires) = kime_engine_dict::lookup(key) {
+            self.hanja_entires = entires;
+            self.index = 0;
+            true
+        } else {
+            false
+        }
+    }
+
+    fn current_hanja(&self) -> char {
+        self.hanja_entires[self.index].0
+    }
+
+    fn try_index(&mut self, index: usize) {
+        self.index = index.min(self.hanja_entires.len() - 1);
+    }
+}
+
+impl InputEngineMode for HanjaMode {
+    fn press_key(&mut self, key: Key, commit_buf: &mut String) -> InputEngineModeResult<bool> {
+        match key.code {
+            KeyCode::Left => {
+                self.index = self
+                    .index
+                    .checked_sub(1)
+                    .unwrap_or(self.hanja_entires.len() - 1);
+                Continue(true)
+            }
+            KeyCode::Right => {
+                self.try_index(self.index + 1);
+                Continue(true)
+            }
+            KeyCode::One
+            | KeyCode::Two
+            | KeyCode::Three
+            | KeyCode::Four
+            | KeyCode::Five
+            | KeyCode::Six
+            | KeyCode::Seven
+            | KeyCode::Eight
+            | KeyCode::Nine => {
+                self.try_index(key.code as usize - KeyCode::One as usize);
+                Continue(true)
+            }
+            _ => {
+                commit_buf.push(self.current_hanja());
+                Exit
+            }
+        }
+    }
+
+    fn preedit_str(&self, buf: &mut String) {
+        let current_hanja = &self.hanja_entires[self.index];
+
+        for (prev_hanja, _) in self.hanja_entires[..self.index].iter() {
+            buf.push(*prev_hanja);
+        }
+
+        buf.push('/');
+        buf.push(current_hanja.0);
+        buf.push('(');
+        buf.push_str(current_hanja.1);
+        buf.push(')');
+
+        if let Some(next_hanjas) = self.hanja_entires.get(self.index + 1..) {
+            for (next_hanja, _) in next_hanjas {
+                buf.push(*next_hanja);
+            }
+        }
+    }
+
+    fn clear_preedit(&mut self, commit_buf: &mut String) -> InputEngineModeResult<()> {
+        commit_buf.push(self.current_hanja());
+        Exit
+    }
+
+    fn reset(&mut self) -> InputEngineModeResult<()> {
+        Exit
+    }
+
+    fn has_preedit(&self) -> bool {
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}

--- a/src/engine/backends/math/src/lib.rs
+++ b/src/engine/backends/math/src/lib.rs
@@ -1,6 +1,6 @@
 use kime_engine_backend::{
     AHashMap, InputEngineMode,
-    InputEngineModeResult::{self, Continue, Exit},
+    InputEngineModeResult::{self, Continue},
     Key, KeyCode,
 };
 use kime_engine_backend_latin::{load_layout, LatinConfig};
@@ -53,7 +53,7 @@ impl InputEngineMode for MathMode {
 
             Continue(true)
         } else {
-            Exit
+            Continue(false)
         }
     }
 

--- a/src/engine/core/Cargo.toml
+++ b/src/engine/core/Cargo.toml
@@ -8,9 +8,9 @@ license = "GPL-3.0"
 [dependencies]
 kime-engine-backend = { path = "../backend" }
 kime-engine-backend-hangul = { path = "../backends/hangul" }
+kime-engine-backend-hanja = { path = "../backends/hanja" }
 kime-engine-backend-latin = { path = "../backends/latin" }
 kime-engine-backend-math = { path = "../backends/math" }
-kime-engine-dict = { path = "../dict" }
 serde = { version = "1.0.124", features = ["derive"] }
 serde_yaml = "0.8.17"
 enum-map = "0.6.4"

--- a/src/engine/core/src/config.rs
+++ b/src/engine/core/src/config.rs
@@ -17,13 +17,20 @@ pub enum InputCategory {
     Math,
 }
 
+#[derive(Serialize, Deserialize, Debug, EnumSetType, Enum, PartialOrd, Ord)]
+#[enumset(serialize_as_list)]
+#[repr(u32)]
+pub enum InputMode {
+    Hanja,
+}
+
 #[derive(Serialize, Deserialize, Clone, Copy, Debug)]
 pub enum HotkeyBehavior {
     Switch(InputCategory),
     Toggle(InputCategory, InputCategory),
+    Mode(InputMode),
     Commit,
     Emoji,
-    Hanja,
 }
 
 impl HotkeyBehavior {
@@ -105,9 +112,9 @@ impl Default for RawConfig {
             },
             category_hotkeys: btreemap! {
                 InputCategory::Hangul => btreemap! {
-                    Key::normal(KeyCode::F9) => Hotkey::new(HotkeyBehavior::Hanja, HotkeyResult::Consume),
-                    Key::normal(KeyCode::HangulHanja) => Hotkey::new(HotkeyBehavior::Hanja, HotkeyResult::Consume),
-                    Key::normal(KeyCode::ControlR) => Hotkey::new(HotkeyBehavior::Hanja, HotkeyResult::Consume),
+                    Key::normal(KeyCode::F9) => Hotkey::new(HotkeyBehavior::Mode(InputMode::Hanja), HotkeyResult::Consume),
+                    Key::normal(KeyCode::HangulHanja) => Hotkey::new(HotkeyBehavior::Mode(InputMode::Hanja), HotkeyResult::Consume),
+                    Key::normal(KeyCode::ControlR) => Hotkey::new(HotkeyBehavior::Mode(InputMode::Hanja), HotkeyResult::Consume),
                 },
                 InputCategory::Math => btreemap! {
                     Key::normal(KeyCode::Enter) => Hotkey::new(HotkeyBehavior::Commit, HotkeyResult::ConsumeIfProcessed),

--- a/src/engine/core/src/config.rs
+++ b/src/engine/core/src/config.rs
@@ -3,7 +3,7 @@ use enumset::EnumSetType;
 use kime_engine_backend::{AHashMap, Key, KeyCode, ModifierState};
 use kime_engine_backend_hangul::{HangulConfig, HangulEngine};
 use kime_engine_backend_latin::{LatinConfig, LatinEngine};
-use kime_engine_backend_math::MathEngine;
+use kime_engine_backend_math::MathMode;
 use maplit::btreemap;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -14,13 +14,13 @@ use std::collections::BTreeMap;
 pub enum InputCategory {
     Latin,
     Hangul,
-    Math,
 }
 
 #[derive(Serialize, Deserialize, Debug, EnumSetType, Enum, PartialOrd, Ord)]
 #[enumset(serialize_as_list)]
 #[repr(u32)]
 pub enum InputMode {
+    Math,
     Hanja,
 }
 
@@ -109,7 +109,7 @@ impl Default for RawConfig {
                 Key::super_(KeyCode::Space) => Hotkey::new(HotkeyBehavior::toggle_hangul_latin(), HotkeyResult::Consume),
                 Key::normal(KeyCode::Muhenkan) => Hotkey::new(HotkeyBehavior::toggle_hangul_latin(), HotkeyResult::Consume),
                 Key::new(KeyCode::E, ModifierState::CONTROL | ModifierState::ALT) => Hotkey::new(HotkeyBehavior::Emoji, HotkeyResult::ConsumeIfProcessed),
-                Key::new(KeyCode::Backslash, ModifierState::CONTROL | ModifierState::ALT) => Hotkey::new(HotkeyBehavior::Switch(InputCategory::Math), HotkeyResult::Consume),
+                Key::new(KeyCode::Backslash, ModifierState::CONTROL | ModifierState::ALT) => Hotkey::new(HotkeyBehavior::Mode(InputMode::Math), HotkeyResult::ConsumeIfProcessed),
             },
             category_hotkeys: btreemap! {
                 InputCategory::Hangul => btreemap! {
@@ -117,14 +117,14 @@ impl Default for RawConfig {
                     Key::normal(KeyCode::HangulHanja) => Hotkey::new(HotkeyBehavior::Mode(InputMode::Hanja), HotkeyResult::Consume),
                     Key::normal(KeyCode::ControlR) => Hotkey::new(HotkeyBehavior::Mode(InputMode::Hanja), HotkeyResult::Consume),
                 },
-                InputCategory::Math => btreemap! {
-                    Key::normal(KeyCode::Enter) => Hotkey::new(HotkeyBehavior::Commit, HotkeyResult::ConsumeIfProcessed),
-                },
             },
             mode_hotkeys: btreemap! {
                 InputMode::Hanja => btreemap! {
                     Key::normal(KeyCode::Enter) => Hotkey::new(HotkeyBehavior::Commit, HotkeyResult::Consume),
-                }
+                },
+                InputMode::Math => btreemap! {
+                    Key::normal(KeyCode::Enter) => Hotkey::new(HotkeyBehavior::Commit, HotkeyResult::ConsumeIfProcessed),
+                },
             },
             xim_preedit_font: ("D2Coding".to_string(), 15.0),
         }
@@ -141,7 +141,7 @@ pub struct Config {
     pub xim_preedit_font: (String, f64),
     pub hangul_engine: HangulEngine,
     pub latin_engine: LatinEngine,
-    pub math_engine: MathEngine,
+    pub math_engine: MathMode,
 }
 
 impl Default for Config {
@@ -173,7 +173,7 @@ impl Config {
             icon_color: raw.icon_color,
             xim_preedit_font: raw.xim_preedit_font,
             latin_engine: LatinEngine::new(&raw.latin),
-            math_engine: MathEngine::new(&raw.latin),
+            math_engine: MathMode::new(&raw.latin),
             hangul_engine,
         }
     }

--- a/src/engine/core/src/lib.rs
+++ b/src/engine/core/src/lib.rs
@@ -69,7 +69,13 @@ impl InputEngine {
     }
 
     fn try_hotkey<'c>(&self, key: &Key, config: &'c Config) -> Option<&'c Hotkey> {
-        if let Some(category_hotkey) = config.category_hotkeys[self.category()].get(key) {
+        if let Some(mode_hotkey) = self
+            .engine_impl
+            .mode
+            .and_then(|mode| config.mode_hotkeys[mode].get(key))
+        {
+            Some(mode_hotkey)
+        } else if let Some(category_hotkey) = config.category_hotkeys[self.category()].get(key) {
             Some(category_hotkey)
         } else if let Some(global) = config.global_hotkeys.get(key) {
             Some(global)
@@ -229,20 +235,18 @@ impl EngineImpl {
 
     pub fn set_mode(&mut self, mode: InputMode) -> bool {
         match mode {
-            InputMode::Hanja => {
-                match self.category {
-                    InputCategory::Hangul => {
-                        if self.hanja_mode.set_key(self.hangul_engine.get_hanja_char()) {
-                            self.mode = Some(InputMode::Hanja);
-                            self.hangul_engine.reset();
-                            true
-                        } else {
-                            false
-                        }
+            InputMode::Hanja => match self.category {
+                InputCategory::Hangul => {
+                    if self.hanja_mode.set_key(self.hangul_engine.get_hanja_char()) {
+                        self.mode = Some(InputMode::Hanja);
+                        self.hangul_engine.reset();
+                        true
+                    } else {
+                        false
                     }
-                    _ => false,
                 }
-            }
+                _ => false,
+            },
         }
     }
 }

--- a/src/engine/core/src/lib.rs
+++ b/src/engine/core/src/lib.rs
@@ -43,6 +43,7 @@ impl InputEngine {
     pub fn set_input_category(&mut self, category: InputCategory) {
         // Reset previous engine
         self.engine_impl.clear_preedit(&mut self.commit_buf);
+        self.engine_impl.mode = None;
         self.engine_impl.category = category;
     }
 

--- a/src/engine/core/src/os.rs
+++ b/src/engine/core/src/os.rs
@@ -51,7 +51,6 @@ mod unix {
             client.set_write_timeout(Some(Duration::from_secs(2))).ok();
             client.read_exact(&mut buf)?;
             match buf[0] {
-                b'2' => Ok(InputCategory::Math),
                 b'1' => Ok(InputCategory::Hangul),
                 _ => Ok(InputCategory::Latin),
             }
@@ -63,7 +62,6 @@ mod unix {
             color: IconColor,
         ) -> io::Result<()> {
             let category = match category {
-                InputCategory::Math => 2,
                 InputCategory::Hangul => 1,
                 InputCategory::Latin => 0,
             };

--- a/src/engine/core/tests/math.rs
+++ b/src/engine/core/tests/math.rs
@@ -1,11 +1,16 @@
 #[macro_use]
 mod shared;
 
-define_layout_test!("dubeolsik", LatinLayout::Qwerty, InputCategory::Math);
+define_layout_test!("dubeolsik", LatinLayout::Qwerty, InputCategory::Latin);
+
+use kime_engine_core::ModifierState;
+
+const MATH: Key = Key::new(Backslash, ModifierState::from_bits_truncate(9));
 
 #[test]
 fn twice_backspace() {
     test_input(&[
+        (MATH, "", ""),
         (Key::normal(Backslash), "\\", ""),
         (Key::normal(Backslash), "", "\\"),
     ]);
@@ -14,6 +19,7 @@ fn twice_backspace() {
 #[test]
 fn pi() {
     test_input(&[
+        (MATH, "", ""),
         (Key::normal(Backslash), "\\", ""),
         (Key::normal(P), "\\p", ""),
         (Key::normal(I), "\\pi", ""),
@@ -28,6 +34,7 @@ fn pi() {
 #[test]
 fn space() {
     test_input(&[
+        (MATH, "", ""),
         (Key::normal(Backslash), "\\", ""),
         (Key::shift(Comma), "\\<", ""),
         (Key::shift(Comma), "\\<<", ""),
@@ -38,6 +45,7 @@ fn space() {
 #[test]
 fn backspace() {
     test_input(&[
+        (MATH, "", ""),
         (Key::normal(Backslash), "\\", ""),
         (Key::normal(P), "\\p", ""),
         (Key::normal(I), "\\pi", ""),


### PR DESCRIPTION
## Summary

Let `Hanja`, `Math` to InputMode this work as another layer of InputCategory

## Note

`InputMode` is life `InputEngine` but it can be turn off without hotkey if mode is disabled, then previous engine is continue work

and `set_mode` may failed like press `Hanja` when there is no preedit string or in latin engine

## Checklist

- [x] I have documented my changes properly to adequate places
- [x] I have updated the docs/CHANGELOG.md
