### PR TITLE
capi에서 설정 파일 로딩에 있는 버그를 고칩니다

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Improve
 
 * Fix wrong symbol name (Gammma -> Gamma)
+* Fix config loading in capi [#465](https://github.com/Riey/kime/pull/465)
 
 ## 2.5.1
 

--- a/src/engine/core/src/config.rs
+++ b/src/engine/core/src/config.rs
@@ -73,11 +73,11 @@ impl Config {
     #[cfg(unix)]
     pub fn load_from_config_dir() -> Option<Self> {
         let dir = xdg::BaseDirectories::with_prefix("kime").ok()?;
-        let engine = dir
+        let config: RawConfig = dir
             .find_config_file("config.yaml")
             .and_then(|config| serde_yaml::from_reader(std::fs::File::open(config).ok()?).ok())
             .unwrap_or_default();
 
-        Some(Self::from_engine_config_with_dir(engine, &dir))
+        Some(Self::from_engine_config_with_dir(config.engine, &dir))
     }
 }


### PR DESCRIPTION
## Summary

capi에서 설정 파일을 로딩하는데에는 `Config::load_from_config_dir` 이 사용됩니다. 근데 이 함수에서는 이번에 새로 바뀐 설정 파일 레이아웃을 따라가지 않고 예전 EngineConfig을 사용하고 있습니다. 그래서 새 설정 파일을 읽지 못하고 항상 default 설정을 가져옵니다.

이것을 고칩니다.

## Note

설정 파일을 xdg config에서 읽어서 설정을 만드는 코드가 여러 군데에 파편화되어있는데 이걸 한 군데로 합쳐서 이런 버그가 안 생기게 하면 좋을 것 같습니다

## Checklist

- [ ] I have documented my changes properly to adequate places
- [x] I have updated the docs/CHANGELOG.md
