### PR TITLE
Correct protocol of indlcator state

### DIFF
--- a/src/engine/core/src/os.rs
+++ b/src/engine/core/src/os.rs
@@ -41,7 +41,7 @@ mod unix {
             client.set_write_timeout(Some(Duration::from_secs(2))).ok();
             client.read_exact(&mut buf)?;
             match buf[0] {
-                b'1' => Ok(InputCategory::Hangul),
+                1 => Ok(InputCategory::Hangul),
                 _ => Ok(InputCategory::Latin),
             }
         }


### PR DESCRIPTION
## Note
global_category_state + kime-indicator 조합이 작동하지 않아서 뭔가 하고 봤더니 여기만 1 대신 b'1' 을 사용해서 혹시 이거 때문이 아닐지 싶네요 제 환경에서 빌드가 깨져서 테스트는 못 해봤습니다

## Checklist

- [ ] I have documented my changes properly to adequate places
- [ ] I have updated the docs/CHANGELOG.md
