### PR TITLE
Fix sebeolsik-3sin-p2 '"'

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Improve
 
 * Update dependencies [#508](https://github.com/Riey/kime/issues/508)
+* Fix sebeolsik-3sin-p2 '"' character [#509](https://github.com/Riey/kime/pull/509)
 
 ## 2.5.5
 

--- a/src/engine/backends/hangul/data/sebeolsik-3sin-p2.yaml
+++ b/src/engine/backends/hangul/data/sebeolsik-3sin-p2.yaml
@@ -46,7 +46,7 @@ S-H: ㄴ
 J: ㅇ
 S-J: "'"
 K: ㄱ
-S-K: "'"
+S-K: "\""
 L: ㅈ
 S-L: ·
 SemiColon: ㅂ


### PR DESCRIPTION
## Summary

Fix wrong mapping in sebeolsik-3sin-p2.
According to this [site](https://pat.im/1136), S-k should print `"`.

## Note

## Checklist

- [ ] I have documented my changes properly to adequate places
Since this PR only fixes a small problem, we don't need to update any documents.
- [x] I have updated the docs/CHANGELOG.md

