### PR TITLE
Pr plus sign in 3 91

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Support johab encoding for preedit string
 * Fix jongseong input bug `$ㅋㅕ + $ㅋㅕ = ㅋㅋ`
 * Added Qt 5.12.9 library build
+* Fix sebeolsik-391 "S-Equal" key
 
 ## 2.5.6
 

--- a/src/engine/backends/hangul/data/sebeolsik-3-91.yaml
+++ b/src/engine/backends/hangul/data/sebeolsik-3-91.yaml
@@ -69,7 +69,7 @@ S-0: ~
 Minus: )
 S-Minus: ;
 Equal: '>'
-S-Equal: '>'
+S-Equal: '+'
 Backslash: ':'
 S-Backslash: \
 OpenBracket: (


### PR DESCRIPTION
## Summary
세벌식 3-91 자판의 `S-Equal` 키에 `+` 대신 `>` 가 배치되어 있던 버그를 수정

## Note
세벌식 3-91 자판에 플러스 기호가 없던 버그를 고쳤습니다.

## Checklist

- [ X ] I have documented my changes properly to adequate places
- [ O ] I have updated the docs/CHANGELOG.md
