### PR TITLE
Fix build error with ubuntu-21.04 Docker

### DIFF
--- a/build-docker/ubuntu-21.04/Dockerfile
+++ b/build-docker/ubuntu-21.04/Dockerfile
@@ -11,7 +11,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --de
 RUN rustc --version
 RUN apt-get install -y build-essential git gcc libclang-11-dev cmake extra-cmake-modules pkg-config zstd
 RUN apt-get install -y libpango1.0-dev libcairo2-dev libgtk2.0-dev libgtk-3-dev libglib2.0 libxcb1
-RUN apt-get install -y qtbase5-dev qtbase5-private-dev libqt5gui5
+RUN apt-get install -y qtbase5-dev qtbase5-private-dev libqt5gui5 libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev
 RUN mkdir -pv /opt/kime-out
 
 COPY src ./src


### PR DESCRIPTION
## Summary
 Fix build error with ubuntu-21.04 docker image.

I didn't test another images, so other docker images also could have same problem.
