### PR TITLE
Fix issue kime icon is not shown on Gnome tray

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Fix jongseong input bug `$ㅋㅕ + $ㅋㅕ = ㅋㅋ`
 * Added Qt 5.12.9 library build
 * Fix sebeolsik-391 "S-Equal" key
+* Let indicator shown on Gnome tray (requires Gnome shell extension, https://extensions.gnome.org/extension/615/appindicator-support/)
 
 ## 2.5.6
 

--- a/src/tools/indicator/src/main.rs
+++ b/src/tools/indicator/src/main.rs
@@ -25,9 +25,14 @@ impl ksni::Tray for KimeTray {
         self.icon_name.into()
     }
 
-    fn title(&self) -> String {
+    fn id(&self) -> String {
         "kime".into()
     }
+
+    fn title(&self) -> String {
+        self.id()
+    }
+
     fn attention_icon_name(&self) -> String {
         self.icon_name.into()
     }


### PR DESCRIPTION
## Summary
Gnome extension for KSNI requires id, so this PR implements `KimeTray`'s `id` method.

## Checklist

- [v] I have documented my changes properly to adequate places
- [v] I have updated the docs/CHANGELOG.md
