### PR TITLE
Fix scan code of F11 / F12

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Improve
 
 * Update configuration.md
+* Correct scan code to properly recognize F11 and F12 key
 
 ## 3.0.1
 

--- a/src/engine/backend/src/keycode.rs
+++ b/src/engine/backend/src/keycode.rs
@@ -247,8 +247,9 @@ impl KeyCode {
             74 => Some(Self::F8),
             75 => Some(Self::F9),
             76 => Some(Self::F10),
-            77 => Some(Self::F11),
-            78 => Some(Self::F12),
+
+            95 => Some(Self::F11),
+            96 => Some(Self::F12),
 
             _ => None,
         }


### PR DESCRIPTION
The Linux "hardware codes" 77 and 78 *usually* point to X11 keycode `Num_Lock` and `Scroll_Lock` each. Common codes for F11 and F12 are 95 and 96.

I said *usually* because `.Xmodmap` could mess up all the keycodes in X11.

## References
- [Code values on Linux (X11), in MDN](https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_code_values#code_values_on_linux_x11)
- `xmodmap -pke` on my computer

## Checklist

- [ ] I have documented my changes properly to adequate places
- [ ] I have updated the docs/CHANGELOG.md
