### PR TITLE
Set default font to Noto Sans

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Update configuration.md
 * Correct scan code to properly recognize F11 and F12 key
 * Fix KDE plasmashell crash #609
+* Set default font to `Noto Sans CJK KR`
 
 ## 3.0.1
 

--- a/res/default_config.yaml
+++ b/res/default_config.yaml
@@ -74,9 +74,9 @@ engine:
       Tab:
         behavior: Commit
         result: ConsumeIfProcessed
-  candidate_font: D2Coding
+  candidate_font: Noto Sans CJK KR
   xim_preedit_font:
-  - D2Coding
+  - Noto Sans CJK KR
   - 15.0
   latin:
     layout: Qwerty

--- a/scripts/control.in
+++ b/scripts/control.in
@@ -6,3 +6,4 @@ Homepage: https://github.com/Riey/kime
 Section: utils
 Priority: optional
 Architecture: %ARCH%
+Recommends: fonts-noto-cjk

--- a/src/engine/config/src/lib.rs
+++ b/src/engine/config/src/lib.rs
@@ -188,8 +188,8 @@ impl Default for EngineConfig {
                     Key::normal(KeyCode::Tab) => Hotkey::new(HotkeyBehavior::Commit, HotkeyResult::ConsumeIfProcessed),
                 },
             },
-            xim_preedit_font: ("D2Coding".to_string(), 15.0),
-            candidate_font: "D2Coding".to_string(),
+            xim_preedit_font: ("Noto Sans CJK KR".to_string(), 15.0),
+            candidate_font: "Noto Sans CJK KR".to_string(),
         }
     }
 }

--- a/src/engine/core/src/config.rs
+++ b/src/engine/core/src/config.rs
@@ -30,7 +30,7 @@ impl Config {
 
         let load_font = |name| {
             db.query(&Query {
-                families: &[Family::Name(name), Family::Serif],
+                families: &[Family::Name(name), Family::Name("D2Coding")],
                 ..Default::default()
             })
             .and_then(|id| db.with_face_data(id, |data, index| (data.to_vec(), index)))


### PR DESCRIPTION
## Summary

Fix #611 (need work for package side)
Alternative of #612

- Set default font to Noto Sans
- Make D2Coding to fallback font

## Note

## Checklist

- [x] I have documented my changes properly to adequate places
- [x] I have updated the docs/CHANGELOG.md
