### PR TITLE
Fix autostart

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Improve
 
+* Fix KDE autostart [#576](https://github.com/Riey/kime/issues/576)
+
 ## 3.0.2
 
 ### Improve

--- a/res/kime.desktop
+++ b/res/kime.desktop
@@ -13,4 +13,4 @@ X-GNOME-AutoRestart=false
 X-GNOME-Autostart-Notify=false
 X-KDE-autostart-after=panel
 X-KDE-StartupNotify=false
-Icon=kime-han-black
+Icon=kime-hangul-black

--- a/res/kime.desktop
+++ b/res/kime.desktop
@@ -11,6 +11,5 @@ X-DBUS-StartupType=Unique
 X-GNOME-Autostart-Phase=Applications
 X-GNOME-AutoRestart=false
 X-GNOME-Autostart-Notify=false
-X-KDE-autostart-after=panel
 X-KDE-StartupNotify=false
 Icon=kime-hangul-black

--- a/res/kime.desktop
+++ b/res/kime.desktop
@@ -8,7 +8,6 @@ Terminal=false
 NoDisplay=true
 StartupNotify=false
 X-DBUS-StartupType=Unique
-X-GNOME-Autostart-Phase=Applications
 X-GNOME-AutoRestart=false
 X-GNOME-Autostart-Notify=false
 X-KDE-StartupNotify=false

--- a/res/kime.desktop
+++ b/res/kime.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Exec=/usr/bin/kime
+Exec=/usr/bin/kime -D
 Name=kime daemon
 Name[ko]=kime 데몬
 Comment=Start kime daemon


### PR DESCRIPTION
## Summary

This PR closes #576 and fixes other various parts of the `kime.desktop` autostart file.

## Note

* #576 seems to have happened because of `systemd-xdg-autostart-generator`, which KDE depends on (since Plasma [5.21](https://invent.kde.org/plasma/plasma-workspace/-/commits/v5.21.0?search=systemd+startup)), [skipping `.desktop` files with the entry `X-GNOME-Autostart-Phase`](https://man.archlinux.org/man/systemd-xdg-autostart-generator.8.en#DESCRIPTION). This will also fix the same issue on any desktop environment with the same behavior.

## Checklist

- [ ] I have documented my changes properly to adequate places
- [x] I have updated the docs/CHANGELOG.md
