### PR TITLE
Fix autostart

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Improve
 
+* Fix KDE autostart [#576](https://github.com/Riey/kime/issues/576)
+
 ## 3.0.2
 
 ### Improve

--- a/res/kime-xdg-autostart
+++ b/res/kime-xdg-autostart
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+
+/usr/bin/kime "#@"
+if systemctl --user is-active --quiet app-kime@autostart.service; then
+	sleep 7s
+fi

--- a/res/kime.desktop
+++ b/res/kime.desktop
@@ -13,4 +13,4 @@ X-GNOME-AutoRestart=false
 X-GNOME-Autostart-Notify=false
 X-KDE-autostart-after=panel
 X-KDE-StartupNotify=false
-Icon=kime-han-black
+Icon=kime-hangul-black

--- a/res/kime.desktop
+++ b/res/kime.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Exec=/usr/bin/kime
+Exec=/usr/bin/kime-xdg-autostart
 Name=kime daemon
 Name[ko]=kime 데몬
 Comment=Start kime daemon

--- a/res/kime.desktop
+++ b/res/kime.desktop
@@ -11,6 +11,5 @@ X-DBUS-StartupType=Unique
 X-GNOME-Autostart-Phase=Applications
 X-GNOME-AutoRestart=false
 X-GNOME-Autostart-Notify=false
-X-KDE-autostart-after=panel
 X-KDE-StartupNotify=false
 Icon=kime-hangul-black

--- a/res/kime.desktop
+++ b/res/kime.desktop
@@ -8,7 +8,6 @@ Terminal=false
 NoDisplay=true
 StartupNotify=false
 X-DBUS-StartupType=Unique
-X-GNOME-Autostart-Phase=Applications
 X-GNOME-AutoRestart=false
 X-GNOME-Autostart-Notify=false
 X-KDE-StartupNotify=false

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -95,6 +95,7 @@ if [ "${KIME_INSTALL_DOC}" -eq "1" ]; then
 fi
 
 install -Dm644 $KIME_OUT/*.desktop -t "$PREFIX/$KIME_AUTOSTART_DIR"
+install -Dm755 $KIME_OUT/kime-xdg-autostart -t "$PREFIX/$KIME_BIN_DIR"
 install -Dm644 $KIME_OUT/icons/64x64/*.png -t "$PREFIX/$KIME_ICON_DIR/hicolor/64x64/apps"
 install -Dm755 $KIME_OUT/libkime_engine.so -t "$PREFIX/$KIME_LIB_DIR"
 


### PR DESCRIPTION
## Summary
This PR closes #576 by introducing a new shell script while fixing other various parts, such as icon name, of the `kime.desktop` autostart file.

## Note

* #576 was caused by `systemd-xdg-autostart-generator`, which KDE depends on since [5.21](https://invent.kde.org/plasma/plasma-workspace/-/commits/v5.21.0?search=systemd+startup), [skipping `.desktop` files with the entry `X-GNOME-Autostart-Phase`](https://man.archlinux.org/man/systemd-xdg-autostart-generator.8.en#DESCRIPTION).
* The user unit `app-kime@autostart` will load when we simply remove the line. However, since `kime` spawns a daemon and exits immediately, systemd will kill the `kime` process because of it exiting before the automatically generated unit's `TimeoutSec`.
* Since the `TimeoutSec` value is [hardcoded to be 5 seconds](https://github.com/systemd/systemd/blob/96f321b6b4cfbe524e3d264564047b03049fe7da/src/xdg-autostart-generator/xdg-autostart-service.c#L610), we can work around this by sleeping for longer than 5 seconds before exiting.
* We introduce a shell script here to sleep for 7 seconds before exiting only if `systemd-xdg-autostart-generator` is running, and `app-kime@autostart.service` is active.
* We can then set the desktop file's `Exec=` to `/usr/bin/kime-xdg-autostart`, the script file.
* This has been tested on both KDE (`systemd-xdg-autostart-generator` dependent) and GNOME (not dependent) by myself.

## Checklist

- [ ] I have documented my changes properly to adequate places
- [x] I have updated the docs/CHANGELOG.md
