### PR TITLE
Make `from_items` public, able to bypass YAML parsing

### DIFF
--- a/src/engine/backends/hangul/src/layout.rs
+++ b/src/engine/backends/hangul/src/layout.rs
@@ -9,7 +9,7 @@ pub struct Layout {
 }
 
 impl Layout {
-    fn from_items(items: HashMap<Key, String>) -> Self {
+    pub fn from_items(items: HashMap<Key, String>) -> Self {
         let mut keymap = KeyMap::default();
 
         for (key, value) in items {


### PR DESCRIPTION
## Summary

## Note

## Checklist

- [ ] I have documented my changes properly to adequate places
- [ ] I have updated the docs/CHANGELOG.md
