### PR TITLE
kime-engine-core: Make hanja/math/emoji features optional

### DIFF
--- a/src/engine/core/Cargo.toml
+++ b/src/engine/core/Cargo.toml
@@ -9,10 +9,10 @@ license = "GPL-3.0-or-later"
 kime-engine-config = { path = "../config", features = ["config-serde"] }
 kime-engine-backend = { path = "../backend" }
 kime-engine-backend-hangul = { path = "../backends/hangul" }
-kime-engine-backend-hanja = { path = "../backends/hanja" }
+kime-engine-backend-hanja = { path = "../backends/hanja", optional = true }
 kime-engine-backend-latin = { path = "../backends/latin" }
-kime-engine-backend-math = { path = "../backends/math" }
-kime-engine-backend-emoji = { path = "../backends/emoji" }
+kime-engine-backend-math = { path = "../backends/math", optional = true }
+kime-engine-backend-emoji = { path = "../backends/emoji", optional = true }
 serde_yaml = "0.9"
 parking_lot = "0.12"
 fontdb = { version = "0.11.2", features = ["fontconfig"] }
@@ -30,3 +30,7 @@ name = "call_key"
 harness = false
 
 [features]
+default = ["hanja", "math", "emoji"]
+hanja = ["dep:kime-engine-backend-hanja"]
+math = ["dep:kime-engine-backend-math"]
+emoji = ["dep:kime-engine-backend-emoji"]


### PR DESCRIPTION
## Summary
해당 mode들이 `cfg(unix)` 이외에서 컴파일되지 않는 `kime-engine-candidate` 의존성을 갖고 있어서, 이를 (임시방편?으로) 제외할 수 있게 feature로 빼두되 default features에는 넣어둡니다.

## Note
- 그러고 보니 [/docs/CONFIGURATION.md](https://github.com/Riey/kime/blob/0b772b8a5ed87347d3f75b28170db7fcf46c361e/docs/CONFIGURATION.md)에는 mode에 관해서 문서화가 되어 있지 않네요 (사실 써본 적도 없습니다 설정 제대로 안 되는 거 같기도 하고)
- wasm으로 kime 컴파일 굴려서 웹에서 사용해보고 있습니다 https://github.com/xnuk/kime-web-playground (https://kime.xnu.kr/)

## Checklist

- [ ] I have documented my changes properly to adequate places
- [ ] I have updated the docs/CHANGELOG.md
