### PR TITLE
Fix to work on wlroots>=0.17.1 by changing increasing order of `serial`

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Add ubuntu-22.10 Dockerfile **[@OctopusET]**
 * Fix KDE autostart [#576](https://github.com/Riey/kime/issues/576)
 * Add unicode prime symbols to math mode. (prime, double prime, triple prime, quadruple prime)
+* Fix to work on wlroots>=0.17.1 (Sway 1.9) [#664](https://github.com/Riey/kime/issues/664)
 
 ## 3.0.2
 

--- a/src/frontends/wayland/src/main.rs
+++ b/src/frontends/wayland/src/main.rs
@@ -177,7 +177,6 @@ impl KimeContext {
 
     fn commit(&mut self) {
         self.im.commit(self.serial);
-        self.serial += 1;
     }
 
     fn commit_string(&mut self, s: String) {
@@ -208,6 +207,7 @@ impl KimeContext {
                 panic!("Unavailable")
             }
             ImEvent::Done => {
+                self.serial += 1;
                 if !self.current_state.activate && self.pending_state.activate {
                     self.engine.update_layout_state();
                     if !self.engine_ready {
@@ -379,7 +379,6 @@ impl KimeContext {
                 key,
                 state: KeyState::Pressed,
             };
-            self.serial += 1;
             self.handle_key_ev(ev);
         } else {
             log::warn!("Received timer event when it has never received RepeatInfo.");


### PR DESCRIPTION
## Summary
Fixes #663

## Note
> The serial number reflects the last state of the zwp_input_method_v2 object known to the client. The value of the serial argument must be equal to the **number of done events** already issued by that object. When the compositor receives a commit request with a serial different than the number of past done events, it must proceed as normal, except it should not change the current state of the zwp_input_method_v2 object.

https://wayland.app/protocols/input-method-unstable-v2#zwp_input_method_v2:request:commit

다른 곳 치우고 `ImEvent::Done`에서만 `serial`을 1씩 증가하게 바꾸니 일단은 작동하는 거 같습니다.

[wlroots/wlroots#4497](https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/4497)을 읽어봤더니, `current_serial`은 0부터 시작해서 `wlr_input_method_v2_send_done`에서 1씩 올리고, 이렇게 예측한 `current_serial`이 받은 `serial`과 다르면 리셋을 해버리는 모양입니다. 다만 한 번 예측이 틀어지면 `current_serial`이 다시 0부터 시작해서 영원히 틀어지는 게 문제가 될 거 같긴 하네요 어떻게 그게 재현이 될 지는 아직 모르겠는데

## Checklist

- [ ] I have documented my changes properly to adequate places
- [x] I have updated the docs/CHANGELOG.md
