### PR TITLE
Update documentation for nixpkgs breaking change

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -49,7 +49,8 @@
 i18n = {
   defaultLocale = "en_US.UTF-8";
   inputMethod = {
-    enabled = "kime";
+    enable = true;
+    type = "kime";
     kime.config = {
       indicator.icon_color = "White";
     };

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ Add this code to your configuration.nix
 i18n = {
   defaultLocale = "en_US.UTF-8";
   inputMethod = {
-    enabled = "kime";
+    enable = true;
+    type = "kime";
     kime.config = {
       indicator.icon_color = "White";
     };


### PR DESCRIPTION
## Summary
While doing due diligence for https://github.com/nixos/nixpkgs/issues/180654 I noticed this repository has documentation for enabling Kime on NixOS.
The fix for 180654 is a breaking change, so this PR updates the Kime documentation.

I haven't updated the changelog because this is a NixOS breaking change, and is documented in the NixOS breaking changes for release 24.11.
Existing non-NixOS users are unaffected, and existing NixOS users will be informed when they update to 24.11.
New users in both cases are unaffected.

## Checklist
- [x] I have documented my changes properly to adequate places
- [x] I have updated the docs/CHANGELOG.md
