### PR TITLE
Fix Qt6 build

### DIFF
--- a/src/frontends/qt5/src/input_context.cc
+++ b/src/frontends/qt5/src/input_context.cc
@@ -99,7 +99,9 @@ void KimeInputContext::preedit_str(kime::RustStr s) {
   fmt.setFontUnderline(true);
   QString qs = QString::fromUtf8((const char *)(s.ptr), s.len);
   this->attributes.push_back(QInputMethodEvent::Attribute{
-      QInputMethodEvent::AttributeType::TextFormat, 0, qs.length(), fmt});
+      QInputMethodEvent::AttributeType::TextFormat,
+      0, static_cast<int>(qs.length()), fmt
+  });
   QInputMethodEvent e(qs, this->attributes);
   this->attributes.clear();
   QCoreApplication::sendEvent(this->focus_object, &e);


### PR DESCRIPTION
## Summary
- [Qt 5: `int QString::length() const`](https://doc.qt.io/qt-5/qstring.html#length)
- [Qt 6: `qsizetype QString::length() const`](https://doc.qt.io/qt-6/qstring.html#length)

So I think it needs to be add explicit casting. (Build error occurs in latest gcc)

## Note

## Checklist

- [ ] I have documented my changes properly to adequate places
- [ ] I have updated the docs/CHANGELOG.md
