### PR TITLE
Fix mismatched cargoDeps in nix and update attribute syntax

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -3,23 +3,24 @@
   debug ? false,
 }:
 let
-  deps = import ./nix/deps.nix { pkgs = pkgs; };
+  src = ./.;
+  deps = import ./nix/deps.nix { inherit pkgs; };
   kimeVersion = builtins.readFile ./VERSION;
   testArgs = if debug then "" else "--release";
+  inherit (pkgs) llvmPackages_18 rustPlatform qt5;
 in
-with pkgs;
-llvmPackages_18.stdenv.mkDerivation rec {
+llvmPackages_18.stdenv.mkDerivation {
   name = "kime";
-  src = ./.;
+  inherit src;
   buildInputs = deps.kimeBuildInputs;
   nativeBuildInputs = deps.kimeNativeBuildInputs ++ [ rustPlatform.cargoSetupHook ];
   version = kimeVersion;
   cargoDeps = rustPlatform.fetchCargoTarball {
     inherit src;
-    #sha256 = "0000000000000000000000000000000000000000000000000000";
-    sha256 = "sha256-hlTxyaE/300CBGIJtFzIh6CT5PcmmqWt8CN428sr2U8=";
+    #hash = "0000000000000000000000000000000000000000000000000000";
+    hash = "sha256-2MG6xigiKdvQX8PR457d6AXswTRPRJBPERvZqemjv24=";
   };
-  LIBCLANG_PATH = "${pkgs.llvmPackages_18.libclang.lib}/lib";
+  LIBCLANG_PATH = "${llvmPackages_18.libclang.lib}/lib";
   dontUseCmakeConfigure = true;
   dontWrapQtApps = true;
   buildPhase = if debug then "bash scripts/build.sh -ad" else "bash scripts/build.sh -ar";
@@ -30,7 +31,7 @@ llvmPackages_18.stdenv.mkDerivation rec {
     KIME_ICON_DIR=share/icons \
     KIME_LIB_DIR=lib \
     KIME_DOC_DIR=share/doc/kime \
-    KIME_QT5_DIR=lib/qt-${pkgs.qt5.qtbase.version} \
+    KIME_QT5_DIR=lib/qt-${qt5.qtbase.version} \
     bash scripts/install.sh "$out"
   '';
   doCheck = true;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking
 
 ### Improve
+- Fix mismatched cargoDeps in nix and update attribute syntax **[@nakoo]**
 
 ## 3.1.1
 

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1722335482,
-        "narHash": "sha256-ogz81JDwIyuX67JC2dZUr3tIPqJABgSKJF9tynZLksQ=",
+        "lastModified": 1725878719,
+        "narHash": "sha256-j80Qunm0RIEMN8CK1gpKpEk1sGCDUuQQndvgRgeGwNk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3563397b2f10ffa1891e1a6ce99d13d960d73acd",
+        "rev": "d344cafc175b4ba0cd3b5f36fddac4a96fecd4de",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -10,11 +10,11 @@
     flake-utils.lib.eachDefaultSystem
       (system:
         let pkgs = import nixpkgs {
-          system = system;
+          inherit system;
         }; in
         {
-          devShell = import ./shell.nix { inherit pkgs; };
-          defaultPackage = import ./default.nix { inherit pkgs; };
+          devShells.default = import ./shell.nix { inherit pkgs; };
+          packages.default = import ./default.nix { inherit pkgs; };
         }
       );
 }

--- a/nix/deps.nix
+++ b/nix/deps.nix
@@ -1,7 +1,6 @@
 { pkgs }:
-with pkgs;
 {
-  kimeBuildInputs = [
+  kimeBuildInputs = with pkgs; [
     dbus
     libdbusmenu
 
@@ -17,7 +16,7 @@ with pkgs;
     # qt6.qtbase
   ];
 
-  kimeNativeBuildInputs = [
+  kimeNativeBuildInputs = with pkgs; [
     python3 # xcb 0.9.0
     pkg-config
     llvmPackages_18.clang

--- a/shell.nix
+++ b/shell.nix
@@ -2,11 +2,11 @@
   pkgs ? import <nixpkgs> { },
 }:
 let
-  deps = import ./nix/deps.nix { pkgs = pkgs; };
+  deps = import ./nix/deps.nix { inherit pkgs; };
   stdenv = pkgs.llvmPackages_18.stdenv;
-  mkShell = (pkgs.mkShell.override { stdenv = stdenv; });
+  mkShell = (pkgs.mkShell.override { inherit stdenv; });
 in
-mkShell {
+pkgs.mkShell {
   name = "kime-shell";
   dontUseCmakeConfigure = true;
   dontWrapQtApps = true;


### PR DESCRIPTION
## Summary

This PR includes

1. fix mismatched cargoDeps in nix
2. update mkDerivation not to use override
3. replace discouraged `with` keyword

```bash
~ % nix-info -m
 - system: `"x86_64-linux"`
 - host os: `Linux 6.6.44, NixOS, 24.11 (Vicuna), 24.11.20240811.a58bc8a`
 - multi-user?: `yes`
 - sandbox: `yes`
 - version: `nix-env (Nix) 2.18.5`
 - channels(root): `""`
 - channels(user): `""`
 - nixpkgs: `/nix/store/h60m1fwahjd2mv6gsg77ji3vb4gpj4dk-source`
 
~ % nix build .\#kime --no-link --print-out-paths 
/nix/store/czi7nb7327z5hwk372kn5hxd16jk432j-kime-3.1.1
```

## Note
`mkDerivation finalAttrs` makes it possible to use `overrideAttrs` properly unlike `rec`.
It's current recommendation model of nixpkgs and there's ongoing discussion to replace `rec` automatically.
 
https://github.com/NixOS/nixpkgs/pull/119942
https://github.com/NixOS/nixpkgs/issues/293452#issuecomment-2209394047

## Checklist

- [x] I have documented my changes properly to adequate places
- [x] I have updated the docs/CHANGELOG.md
