### PR TITLE
Fix rust-toolchain.toml toolchain version

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,2 @@
 [toolchain]
 channel = "1.81"
-profile = "minimal"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
-channel = "stable"
+channel = "1.81"
+profile = "minimal"


### PR DESCRIPTION
## Summary
fix rust-toolchain.toml file to use rustc 1.81 at compile #688 
## Note
at least 1.84(stable), upper problem is not solved
## Checklist

- [ ] I have documented my changes properly to adequate places
- [ ] I have updated the docs/CHANGELOG.md
