### PR TITLE
Add .cargo/config.toml

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = [ "-Clink-args=-L./target/release"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.81"
+channel = "stable"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,2 @@
 [toolchain]
 channel = "1.81"
-profile = "minimal"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
-channel = "stable"
+channel = "1.81"
+profile = "minimal"


### PR DESCRIPTION
## Summary
rustc not use cmake LD_PATH see(https://github.com/Riey/kime/issues/693#issuecomment-2612017513)
thus, add config.toml to add link-args.
this solution work from stable to nightly rustc, rust-toolchain.toml can use stable channel.

## Note

## Checklist

- [ ] I have documented my changes properly to adequate places
- [ ] I have updated the docs/CHANGELOG.md
