### PR TITLE
Bump up Github Action Ubuntu version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,6 +52,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: Install Rustfmt
+        run: rustup component add rustfmt
       - name: Check Rustfmt
         run: cargo fmt -- --check
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v4
@@ -35,7 +35,7 @@ jobs:
     - run: nix develop -c cargo test
 
   cargo-deny:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         checks:
@@ -48,7 +48,7 @@ jobs:
         command: check ${{ matrix.checks }}
 
   format:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4
@@ -56,7 +56,7 @@ jobs:
         run: cargo fmt -- --check
 
   spell-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - uses: crate-ci/typos@master

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   create-release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     outputs:
       url: ${{ steps.create_release.outputs.upload_url }}
@@ -28,7 +28,7 @@ jobs:
           prerelease: false
 
   build-engine:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4
@@ -61,7 +61,7 @@ jobs:
       - build-engine
       - create-release
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4
@@ -112,7 +112,7 @@ jobs:
       - build-engine
       - create-release
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     strategy:
       matrix:
@@ -180,7 +180,7 @@ jobs:
       - build-engine
       - create-release
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     strategy:
       matrix:
@@ -244,7 +244,7 @@ jobs:
       - build-qt6
       - create-release
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   create-release:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
 
     outputs:
       url: ${{ steps.create_release.outputs.upload_url }}
@@ -28,7 +28,7 @@ jobs:
           prerelease: false
 
   build-engine:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4
@@ -61,7 +61,7 @@ jobs:
       - build-engine
       - create-release
 
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4
@@ -112,7 +112,7 @@ jobs:
       - build-engine
       - create-release
 
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:
@@ -180,7 +180,7 @@ jobs:
       - build-engine
       - create-release
 
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:
@@ -244,7 +244,7 @@ jobs:
       - build-qt6
       - create-release
 
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
> This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will
> be removed on 2025-04-15. For more details, see
> https://github.com/actions/runner-images/issues/11101

## Checklist

- [ ] I have documented my changes properly to adequate places
- [ ] I have updated the docs/CHANGELOG.md
