### PR TITLE
fix(wayland): prevent selection deletion on Ctrl shortcuts

### DIFF
--- a/src/engine/core/src/lib.rs
+++ b/src/engine/core/src/lib.rs
@@ -94,12 +94,6 @@ impl InputEngine {
         self.try_get_global_input_category_state(config);
 
         let mut ret = InputResult::empty();
-        if matches!(
-            key.code,
-            KeyCode::ControlL | KeyCode::ControlR | KeyCode::AltL | KeyCode::AltR | KeyCode::Shift
-        ) {
-            return ret;
-        }
 
         if let Some(hotkey) = self.try_hotkey(key, config) {
             let mut processed = false;
@@ -151,6 +145,12 @@ impl InputEngine {
             ret |= InputResult::CONSUMED;
         } else if key.code == KeyCode::Shift {
             // ignore shift key
+        } else if matches!(
+            key.code,
+            KeyCode::ControlL | KeyCode::ControlR | KeyCode::AltL | KeyCode::AltR | KeyCode::Shift
+        ) {
+            ret |= self.current_result();
+            return ret;
         } else {
             // clear preedit when get unhandled key
             if self.engine_impl.has_preedit() {

--- a/src/engine/core/src/lib.rs
+++ b/src/engine/core/src/lib.rs
@@ -94,6 +94,12 @@ impl InputEngine {
         self.try_get_global_input_category_state(config);
 
         let mut ret = InputResult::empty();
+        if matches!(
+            key.code,
+            KeyCode::ControlL | KeyCode::ControlR | KeyCode::AltL | KeyCode::AltR | KeyCode::Shift
+        ) {
+            return ret;
+        }
 
         if let Some(hotkey) = self.try_hotkey(key, config) {
             let mut processed = false;
@@ -147,7 +153,9 @@ impl InputEngine {
             // ignore shift key
         } else {
             // clear preedit when get unhandled key
-            self.clear_preedit();
+            if self.engine_impl.has_preedit() {
+                self.clear_preedit();
+            }
         }
 
         ret |= self.current_result();

--- a/src/frontends/wayland/src/input_method_v1.rs
+++ b/src/frontends/wayland/src/input_method_v1.rs
@@ -52,6 +52,7 @@ struct KimeContext {
     /// is zero). `Some(..)` if `RepeatInfo` is known and kime-wayland started tracking the press
     /// state of keys.
     repeat_state: Option<(RepeatInfo, PressState)>,
+    last_preedit_len: usize,
 }
 
 impl Drop for KimeContext {
@@ -86,6 +87,7 @@ impl KimeContext {
                 },
                 PressState::NotPressing,
             )),
+            last_preedit_len: 0,
         }
     }
 
@@ -127,14 +129,18 @@ impl KimeContext {
 
     fn clear_preedit(&mut self) {
         if let Some(im_ctx) = &mut self.im_ctx {
-            im_ctx.preedit_cursor(0);
-            im_ctx.preedit_styling(0, 0, ZWP_TEXT_INPUT_V1_PREEDIT_STYLE_NONE);
-            im_ctx.preedit_string(self.serial, String::new(), String::new());
+            if self.last_preedit_len > 0 {
+                im_ctx.preedit_cursor(0);
+                im_ctx.preedit_styling(0, 0, ZWP_TEXT_INPUT_V1_PREEDIT_STYLE_NONE);
+                im_ctx.preedit_string(self.serial, String::new(), String::new());
+                self.last_preedit_len = 0;
+            }
         }
     }
 
     fn preedit(&mut self, s: String) {
         if let Some(im_ctx) = &mut self.im_ctx {
+            self.last_preedit_len = s.len();
             im_ctx.preedit_cursor(s.len() as _);
             im_ctx.preedit_styling(0, s.len() as _, ZWP_TEXT_INPUT_V1_PREEDIT_STYLE_UNDERLINE);
             im_ctx.preedit_string(self.serial, s.clone(), s);

--- a/src/frontends/wayland/src/input_method_v2.rs
+++ b/src/frontends/wayland/src/input_method_v2.rs
@@ -68,6 +68,7 @@ struct KimeContext {
     /// is zero). `Some(..)` if `RepeatInfo` is known and kime-wayland started tracking the press
     /// state of keys.
     repeat_state: Option<(RepeatInfo, PressState)>,
+    last_preedit_len: usize,
 }
 
 impl Drop for KimeContext {
@@ -102,6 +103,7 @@ impl KimeContext {
             grab,
             timer,
             repeat_state: None,
+            last_preedit_len: 0,
         }
     }
 
@@ -146,10 +148,14 @@ impl KimeContext {
     }
 
     fn clear_preedit(&mut self) {
-        self.im.set_preedit_string(String::new(), -1, -1);
+        if self.last_preedit_len > 0 {
+            self.im.set_preedit_string(String::new(), -1, -1);
+            self.last_preedit_len = 0;
+        }
     }
 
     fn preedit(&mut self, s: String) {
+        self.last_preedit_len = s.len();
         let len = s.len();
         self.im.set_preedit_string(s, 0, len as _);
     }


### PR DESCRIPTION
## Summary
Ctrl 모디파이어 활성상태에서 C 입력시 clear_preedit이 호출되는데 이것이 선택 영역에 대한 deletebackward를 입력하는 것으로 처리되어 선택영역이 지워지게됩니다. 이후 Ctrl-c가 입력되고 지워진 영역에 복사가 이루어지어 복사가 안되는 것처럼 보이게 됨니다.
모디파이어키를 처리하지 않고, 비어있는 preedit에 clear_preedit 호출을 막하 실제 preedit이 있는 경우만 clear_preedit이 호출되도록 변경했습니다
## Note
https://github.com/Riey/kime/issues/714
## Checklist

- [ ] I have documented my changes properly to adequate places
- [ ] I have updated the docs/CHANGELOG.md
