### PR TITLE
fix(xim): handle None from from_hardware_code without panic (#721)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Remove `kime-engine-cffi`
 * fix(wayland input_method_v2): not return unwarp **[@racakenon]** [#715](https://github.com/Riey/kime/715)
 * feat(engine): Let default `Alt_R` hotkey accept `Alt` modifier [#719](https://github.com/Riey/kime/719)
+* fix(xim): handle None from from_hardware_code without panic [#721](https://github.com/Riey/kime/721)
 
 ## 3.1.1
 
@@ -486,3 +487,4 @@ sebeolsik-sin1995 -> sebeolsik-3sin-1995
 [@Riey]: https://github.com/Riey
 [@kpqi5858]: https://github.com/kpqi5858
 [@racakenon]: https://github.com/racakenon
+[@strictpvp]: https://github.com/strictpvp/

--- a/src/frontends/xim/src/handler.rs
+++ b/src/frontends/xim/src/handler.rs
@@ -346,15 +346,16 @@ impl<C: HasConnection> ServerHandler<X11rbServer<C>> for KimeHandler {
             state.insert(ModifierState::SUPER);
         }
 
-        let ret = user_ic.user_data.engine.press_key(
-            Key::new(
-                KeyCode::from_hardware_code(xev.detail as u16, numlock).unwrap(),
-                state,
-            ),
-            &self.config,
-        );
-
-        self.process_input_result(server, user_ic, ret)
+        if let Some(keycode) = KeyCode::from_hardware_code(xev.detail as u16, numlock) {
+            let ret = user_ic
+                .user_data
+                .engine
+                .press_key(Key::new(keycode, state), &self.config);
+            self.process_input_result(server, user_ic, ret)
+        } else {
+            log::warn!("Unknown hardware keycode: {}", xev.detail);
+            return Ok(false);
+        }
     }
 
     fn handle_destroy_ic(


### PR DESCRIPTION
## Summary

kime-xim이 None 값을 처리하지 못해 패닉이 나는 것을 수정했습니다.

## Note

Fixes #721 

## Checklist

- [ ] I have documented my changes properly to adequate places
- [x] I have updated the docs/CHANGELOG.md
