### PR TITLE
Build Dockerfile for Ubuntu 24.04 and Debian Bookworm.

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -94,6 +94,10 @@ emerge -av kime
 git clone https://github.com/riey/kime
 cd kime
 
+export DOCKER_BUILDKIT=0
+export COMPOSE_DOCKER_CLI_BUILD=0
+# 도커 빌드시 Buildkit을 쓰지 않고 레거시 방식으로 빌드하기 위함
+
 docker build --file build-docker/<배포판 경로>/Dockerfile --tag kime-build:git .
 docker run --name kime kime-build:git
 docker cp kime:/opt/kime-out/kime.tar.xz .

--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ Building with docker does not requires any other dependencies.
 git clone https://github.com/riey/kime
 cd kime
 
+export DOCKER_BUILDKIT=0
+export COMPOSE_DOCKER_CLI_BUILD=0
+# This is Docker build image using legacy
+
 docker build --file build-docker/<distro path>/Dockerfile --tag kime-build:git .
 docker run --name kime kime-build:git
 docker cp kime:/opt/kime-out/kime.tar.zst .

--- a/build-docker/debian-bookworm/Dockerfile
+++ b/build-docker/debian-bookworm/Dockerfile
@@ -1,0 +1,36 @@
+FROM rust:slim-bookworm
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+WORKDIR /opt/kime
+
+RUN echo " \n\
+deb http://ftp.kr.debian.org/debian/ sid main contrib non-free\n\
+#deb http://ftp.kr.debian.org/debian/ sid-updates main contrib non-free\n\
+#deb http://security.debian.org/ sid/updates main\n\
+#deb http://ftp.debian.org/debian bookworm-backports main\n\
+" > /etc/apt/sources.list
+RUN apt-get update
+RUN apt-get install -y build-essential git gcc clang libclang-dev cmake extra-cmake-modules pkg-config zstd
+RUN apt-get install -y libpango1.0-dev libcairo2-dev libgtk-4-dev libgtk-3-dev libglib2.0-0t64 libxcb1
+RUN apt-get install -y qtbase5-dev qtbase5-private-dev libqt5gui5t64 qt6-base-dev qt6-base-private-dev libxcb-shape0-dev libxcb-xfixes0-dev
+RUN mkdir -pv /opt/kime-out
+
+COPY src ./src
+
+COPY Cargo.toml .
+COPY Cargo.lock .
+
+RUN cargo fetch
+
+COPY res ./res
+COPY ci ./ci
+COPY docs ./docs
+COPY scripts ./scripts
+COPY LICENSE .
+COPY NOTICE.md .
+COPY README.ko.md .
+COPY README.md .
+COPY VERSION .
+
+ENTRYPOINT [ "ci/build_deb.sh" ]

--- a/build-docker/ubuntu-24.04/Dockerfile
+++ b/build-docker/ubuntu-24.04/Dockerfile
@@ -1,0 +1,36 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive \
+  PATH=/root/.cargo/bin:$PATH
+
+WORKDIR /opt/kime
+
+RUN apt-get update
+RUN apt-get install -y curl apt-utils \
+                       build-essential git gcc libclang-dev cmake extra-cmake-modules pkg-config zstd \
+                       libpango1.0-dev libcairo2-dev libgtk-4-dev libgtk-3-dev libglib2.0 libxcb1 \
+                       qtbase5-dev qtbase5-private-dev libqt5gui5 \
+					   qt6-base-dev qt6-base-private-dev \
+                       libxcb-shape0-dev libxcb-xfixes0-dev
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --no-modify-path --profile minimal
+RUN rustc --version
+RUN mkdir -pv /opt/kime-out
+
+COPY src /opt/kime/src
+
+COPY Cargo.toml /opt/kime
+COPY Cargo.lock /opt/kime
+
+RUN cargo fetch
+
+COPY res /opt/kime/res
+COPY ci /opt/kime/ci
+COPY docs /opt/kime/docs
+COPY scripts /opt/kime/scripts
+COPY LICENSE /opt/kime
+COPY NOTICE.md /opt/kime
+COPY README.ko.md /opt/kime
+COPY README.md /opt/kime
+COPY VERSION /opt/kime
+
+ENTRYPOINT [ "ci/build_deb.sh" ]


### PR DESCRIPTION
## Summary
At Build for Debian Bookworm and Ubuntu 24.04 noble.
Use This Dockerfile.
## Note
This Dockerfile can make for Debian Bookworm and ubuntu 24.04.
## Checklist

- [ ] I have documented my changes properly to adequate places
- [ ] I have updated the docs/CHANGELOG.md
