### PR TITLE
openSUSE package provided by default repository

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -83,11 +83,9 @@ emaint sync -r riey
 emerge -av kime
 ```
 
-### 오픈수세
+### 오픈수세 (2026년 01월 04일 업데이트 이후)
 
 ```
-zypper ar https://download.opensuse.org/repositories/M17N/openSUSE_Tumbleweed/M17N.repo # 오픈수세 Tumbleweed 레포지토리
-zypper ar https://download.opensuse.org/repositories/M17N/16.0/M17N.repo # 오픈수세 Leap 16 레포지토리
 zypper refresh
 zypper in kime
 ```

--- a/README.ko.md
+++ b/README.ko.md
@@ -86,7 +86,8 @@ emerge -av kime
 ### 오픈수세
 
 ```
-zypper ar https://download.opensuse.org/repositories/home:/Kernalix7/openSUSE_Tumbleweed/home:Kernalix7.repo
+zypper ar https://download.opensuse.org/repositories/M17N/openSUSE_Tumbleweed/M17N.repo # 오픈수세 Tumbleweed 레포지토리
+zypper ar https://download.opensuse.org/repositories/M17N/16.0/M17N.repo # 오픈수세 Leap 16 레포지토리
 zypper refresh
 zypper in kime
 ```

--- a/README.ko.md
+++ b/README.ko.md
@@ -83,10 +83,12 @@ emaint sync -r riey
 emerge -av kime
 ```
 
-### 오픈수세 (2026년 01월 04일 업데이트 이후)
+### 오픈수세
+
+2026년 01월 04일 이후 공식 패키지가 제공되고 있습니다.
+[openSUSE Software](https://software.opensuse.org/package/kime)
 
 ```
-zypper refresh
 zypper in kime
 ```
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ emerge -av kime
 ### openSUSE
 
 ```
-zypper ar https://download.opensuse.org/repositories/home:/Kernalix7/openSUSE_Tumbleweed/home:Kernalix7.repo
+zypper ar https://download.opensuse.org/repositories/M17N/openSUSE_Tumbleweed/M17N.repo # for Tumbleweed
+zypper ar https://download.opensuse.org/repositories/M17N/16.0/M17N.repo # for Leap 16
 zypper refresh
 zypper in kime
 ```

--- a/README.md
+++ b/README.md
@@ -85,10 +85,11 @@ emaint sync -r riey
 emerge -av kime
 ```
 
-### openSUSE (after 2026 Jan 04 release)
+### openSUSE
+
+After 2026 Jan 04, official package is provided by [openSUSE Software](https://software.opensuse.org/package/kime)
 
 ```
-zypper refresh
 zypper in kime
 ```
 

--- a/README.md
+++ b/README.md
@@ -85,11 +85,9 @@ emaint sync -r riey
 emerge -av kime
 ```
 
-### openSUSE
+### openSUSE (after 2026 Jan 04 release)
 
 ```
-zypper ar https://download.opensuse.org/repositories/M17N/openSUSE_Tumbleweed/M17N.repo # for Tumbleweed
-zypper ar https://download.opensuse.org/repositories/M17N/16.0/M17N.repo # for Leap 16
 zypper refresh
 zypper in kime
 ```

--- a/src/frontends/qt5/src/plugin.hpp
+++ b/src/frontends/qt5/src/plugin.hpp
@@ -6,10 +6,13 @@
 #include <QtPlugin>
 #include <qpa/qplatforminputcontextplugin_p.h>
 
+#ifndef KIME_QT_IID
+#define KIME_QT_IID "org.qt-project.Qt.QPlatformInputContextFactoryInterface"
+#endif
+
 class KimePlatformInputContextPlugin : public QPlatformInputContextPlugin {
   Q_OBJECT
-  Q_PLUGIN_METADATA(IID QPlatformInputContextFactoryInterface_iid FILE
-                    "kime.json")
+  Q_PLUGIN_METADATA(IID KIME_QT_IID FILE "kime.json")
 
 private:
   kime::InputEngine *engine = nullptr;

--- a/src/frontends/qt6/CMakeLists.txt
+++ b/src/frontends/qt6/CMakeLists.txt
@@ -5,7 +5,6 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
 
 find_package(Qt6 6.0.0 QUIET COMPONENTS Gui QUIET)
-find_package(Qt5 5.1.0 QUIET COMPONENTS Gui QUIET)
 
 if(NOT Qt6_FOUND)
     return()
@@ -13,6 +12,7 @@ endif()
 
 add_library(kime-qt6 SHARED ../qt5/src/plugin.cc ../qt5/src/input_context.cc)
 
-target_include_directories(kime-qt6 PRIVATE ${Qt6Gui_PRIVATE_INCLUDE_DIRS} ${Qt5Gui_PRIVATE_INCLUDE_DIRS} ${KIME_INCLUDE})
+target_compile_definitions(kime-qt6 PRIVATE KIME_QT_IID="org.qt-project.Qt.QPlatformInputContextFactoryInterface.5.1")
+target_include_directories(kime-qt6 PRIVATE ${Qt6Gui_PRIVATE_INCLUDE_DIRS} ${KIME_INCLUDE})
 target_link_directories(kime-qt6 PRIVATE ${KIME_LIB_DIRS})
 target_link_libraries(kime-qt6 PRIVATE ${KIME_ENGINE} Qt6::Gui)


### PR DESCRIPTION
## Summary
After 2026 Jan 04, the kime package is provided by openSUSE software.

## Note
User just type to install kime : zypper in kime

Note. Request history below
https://build.opensuse.org/requests/1325051

## Checklist

- [X] I have documented my changes properly to adequate places
- [X] I have updated the docs/CHANGELOG.md
