### PR TITLE
Add .5.1 suffix to Qt6 input context plugin IID and Fix repo

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -83,11 +83,9 @@ emaint sync -r riey
 emerge -av kime
 ```
 
-### 오픈수세
+### 오픈수세 (텀블위드)
 
-```
-zypper ar https://download.opensuse.org/repositories/home:/Kernalix7/openSUSE_Tumbleweed/home:Kernalix7.repo
-zypper refresh
+```드
 zypper in kime
 ```
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -85,7 +85,7 @@ emerge -av kime
 
 ### 오픈수세 (텀블위드)
 
-```드
+```
 zypper in kime
 ```
 

--- a/README.md
+++ b/README.md
@@ -85,11 +85,9 @@ emaint sync -r riey
 emerge -av kime
 ```
 
-### openSUSE
+### openSUSE (Tumbleweed)
 
 ```
-zypper ar https://download.opensuse.org/repositories/home:/Kernalix7/openSUSE_Tumbleweed/home:Kernalix7.repo
-zypper refresh
 zypper in kime
 ```
 

--- a/src/frontends/qt5/src/plugin.hpp
+++ b/src/frontends/qt5/src/plugin.hpp
@@ -6,10 +6,13 @@
 #include <QtPlugin>
 #include <qpa/qplatforminputcontextplugin_p.h>
 
+#ifndef KIME_QT_IID
+#define KIME_QT_IID "org.qt-project.Qt.QPlatformInputContextFactoryInterface"
+#endif
+
 class KimePlatformInputContextPlugin : public QPlatformInputContextPlugin {
   Q_OBJECT
-  Q_PLUGIN_METADATA(IID QPlatformInputContextFactoryInterface_iid FILE
-                    "kime.json")
+  Q_PLUGIN_METADATA(IID KIME_QT_IID FILE "kime.json")
 
 private:
   kime::InputEngine *engine = nullptr;

--- a/src/frontends/qt6/CMakeLists.txt
+++ b/src/frontends/qt6/CMakeLists.txt
@@ -4,7 +4,8 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
 
-find_package(Qt6 6.0.0 QUIET COMPONENTS Gui QUIET)
+find_package(Qt6 6.0.0 QUIET COMPONENTS Gui GuiPrivate QUIET)
+find_package(Qt5 5.1.0 QUIET COMPONENTS Gui QUIET)
 
 if(NOT Qt6_FOUND)
     return()
@@ -13,6 +14,6 @@ endif()
 add_library(kime-qt6 SHARED ../qt5/src/plugin.cc ../qt5/src/input_context.cc)
 
 target_compile_definitions(kime-qt6 PRIVATE KIME_QT_IID="org.qt-project.Qt.QPlatformInputContextFactoryInterface.5.1")
-target_include_directories(kime-qt6 PRIVATE ${Qt6Gui_PRIVATE_INCLUDE_DIRS} ${KIME_INCLUDE})
+target_include_directories(kime-qt6 PRIVATE ${KIME_INCLUDE})
 target_link_directories(kime-qt6 PRIVATE ${KIME_LIB_DIRS})
-target_link_libraries(kime-qt6 PRIVATE ${KIME_ENGINE} Qt6::Gui)
+target_link_libraries(kime-qt6 PRIVATE ${KIME_ENGINE} Qt6::Gui Qt6::GuiPrivate)

--- a/src/frontends/qt6/CMakeLists.txt
+++ b/src/frontends/qt6/CMakeLists.txt
@@ -5,7 +5,6 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
 
 find_package(Qt6 6.0.0 QUIET COMPONENTS Gui QUIET)
-find_package(Qt5 5.1.0 QUIET COMPONENTS Gui QUIET)
 
 if(NOT Qt6_FOUND)
     return()
@@ -13,6 +12,7 @@ endif()
 
 add_library(kime-qt6 SHARED ../qt5/src/plugin.cc ../qt5/src/input_context.cc)
 
-target_include_directories(kime-qt6 PRIVATE ${Qt6Gui_PRIVATE_INCLUDE_DIRS} ${Qt5Gui_PRIVATE_INCLUDE_DIRS} ${KIME_INCLUDE})
+target_compile_definitions(kime-qt6 PRIVATE KIME_QT_IID="org.qt-project.Qt.QPlatformInputContextFactoryInterface.5.1")
+target_include_directories(kime-qt6 PRIVATE ${Qt6Gui_PRIVATE_INCLUDE_DIRS} ${KIME_INCLUDE})
 target_link_directories(kime-qt6 PRIVATE ${KIME_LIB_DIRS})
 target_link_libraries(kime-qt6 PRIVATE ${KIME_ENGINE} Qt6::Gui)


### PR DESCRIPTION
## Summary
Add .5.1 suffix to Qt6 input context plugin IID
Fix openSUSE Repository into OBS home > oss repo

## Note
In KDE latest version, QT_IM_MODULE=kime is unable to use on Qt6.
cuz IID is not set, system bypass kime and use other plugins.
i set the IID suffix to fix this issue.

also, SUSE user will more Happy! kime is now can one-step install without adding repository.
I request to add kime into openSUSE repo-oss repository, and accecpted.
following this history.
https://software.opensuse.org/package/kime
https://build.opensuse.org/requests/1325051

## Checklist

- [X] I have documented my changes properly to adequate places
- [X] I have updated the docs/CHANGELOG.md
