### PR TITLE
Update dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -786,15 +786,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9"
 
 [[package]]
-name = "daemonize"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab8bfdaacb3c887a54d41bdf48d3af8873b3f5566469f8ba21b92057509f116e"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "darling"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1644,11 +1635,11 @@ name = "kime"
 version = "0.1.0"
 dependencies = [
  "ctrlc",
- "daemonize",
  "kime-engine-core",
  "kime-run-dir",
  "kime-version",
  "log",
+ "nix 0.30.1",
  "pico-args",
 ]
 
@@ -1665,8 +1656,8 @@ dependencies = [
 name = "kime-check"
 version = "0.1.0"
 dependencies = [
- "ansi_term",
  "kime-engine-core",
+ "owo-colors",
  "pad",
  "serde_yaml",
  "strum 0.26.3",
@@ -2528,6 +2519,12 @@ checksum = "490d3a563d3122bf7c911a59b0add9389e5ec0f5f0c3ac6b91ff235a0e6a7f90"
 dependencies = [
  "ttf-parser 0.24.0",
 ]
+
+[[package]]
+name = "owo-colors"
+version = "4.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
 
 [[package]]
 name = "pad"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -122,6 +131,12 @@ checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anyhow"
@@ -200,7 +215,7 @@ version = "0.69.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
  "itertools 0.12.1",
@@ -228,9 +243,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "block"
@@ -330,7 +345,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da6bc11b07529f16944307272d5bd9b22530bc7d05751717c9d416586cedab49"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "indexmap 1.9.3",
  "log",
  "proc-macro2",
@@ -431,31 +446,35 @@ dependencies = [
  "atty",
  "bitflags 1.3.2",
  "strsim 0.8.0",
- "textwrap 0.11.0",
+ "textwrap",
  "unicode-width",
  "vec_map",
 ]
 
 [[package]]
 name = "clap"
-version = "3.2.25"
+version = "4.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
+checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
 dependencies = [
- "bitflags 1.3.2",
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
+dependencies = [
+ "anstyle",
  "clap_lex",
- "indexmap 1.9.3",
- "textwrap 0.16.1",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
-]
+checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "clipboard-win"
@@ -632,6 +651,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "core_maths"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
+dependencies = [
+ "libm",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -642,25 +670,24 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.4.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c76e09c1aae2bc52b3d2f29e13c6572553b30c4aa1b8a49fd70de6412654cb"
+checksum = "4d883447757bb0ee46f233e9dc22eb84d93a9508c9b868687b274fc431d886bf"
 dependencies = [
+ "alloca",
  "anes",
- "atty",
  "cast",
  "ciborium",
- "clap 3.2.25",
+ "clap 4.5.54",
  "criterion-plot",
- "itertools 0.10.5",
- "lazy_static",
+ "itertools 0.13.0",
  "num-traits",
  "oorandom",
+ "page_size",
  "plotters",
  "rayon",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "walkdir",
@@ -668,12 +695,12 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.5.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+checksum = "ed943f81ea2faa8dcecbbfa50164acf95d555afec96a27871663b300e387b2e4"
 dependencies = [
  "cast",
- "itertools 0.10.5",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -1167,14 +1194,16 @@ dependencies = [
 
 [[package]]
 name = "fontdb"
-version = "0.11.2"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "652aa0009b1406e40114685c96ea2c01069e1c035ad6c340999fa08213fad4c5"
+checksum = "457e789b3d1202543297a350643cf459f836cade38934e7a4cf6a39e7cde2905"
 dependencies = [
  "fontconfig-parser",
  "log",
- "memmap2 0.5.10",
- "ttf-parser 0.18.1",
+ "memmap2 0.9.9",
+ "slotmap",
+ "tinyvec",
+ "ttf-parser 0.25.1",
 ]
 
 [[package]]
@@ -1416,6 +1445,12 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -1860,9 +1895,9 @@ checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "libdbus-sys"
@@ -1892,6 +1927,12 @@ dependencies = [
  "cfg-if",
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1969,6 +2010,15 @@ name = "memmap2"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a5a03cefb0d953ec0be133036f14e109412fa594edc2f77227249db66cc3ed"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "memmap2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "744133e4a0e0a658e1374cf3bf8e415c4052a15a111acd372764c55b4177d490"
 dependencies = [
  "libc",
 ]
@@ -2168,7 +2218,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.10.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2240,13 +2290,13 @@ checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-derive"
-version = "0.3.3"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2367,7 +2417,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.10.0",
  "block2 0.5.1",
  "libc",
  "objc2 0.5.2",
@@ -2383,7 +2433,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.10.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation",
@@ -2422,7 +2472,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.10.0",
  "block2 0.5.1",
  "libc",
  "objc2 0.5.2",
@@ -2434,7 +2484,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.10.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation",
@@ -2446,7 +2496,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.10.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation",
@@ -2464,12 +2514,6 @@ name = "oorandom"
 version = "11.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
-
-[[package]]
-name = "os_str_bytes"
-version = "6.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 
 [[package]]
 name = "owned_ttf_parser"
@@ -2496,6 +2540,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ad9b889f1b12e0b9ee24db044b5129150d5eada288edc800f789928dc8c0e3"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -2775,7 +2829,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -2825,7 +2879,7 @@ version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2844,9 +2898,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.17"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -3074,24 +3128,24 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"
-version = "0.24.1"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.24.3"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 1.0.109",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -3145,12 +3199,6 @@ checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 
 [[package]]
 name = "thiserror"
@@ -3328,15 +3376,18 @@ checksum = "7b3e06c9b9d80ed6b745c7159c40b311ad2916abb34a49e9be2653b90db0d8dd"
 
 [[package]]
 name = "ttf-parser"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0609f771ad9c6155384897e1df4d948e692667cc0588548b68eb44d052b27633"
-
-[[package]]
-name = "ttf-parser"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8686b91785aff82828ed725225925b33b4fde44c4bb15876e5f7c832724c420a"
+
+[[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+dependencies = [
+ "core_maths",
+]
 
 [[package]]
 name = "typenum"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -391,6 +391,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "cgl"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1007,7 +1013,7 @@ dependencies = [
  "bytemuck",
  "egui",
  "glow",
- "memoffset 0.6.5",
+ "memoffset",
  "tracing",
  "wasm-bindgen",
  "web-sys",
@@ -1367,7 +1373,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc93b03242719b8ad39fb26ed2b01737144ce7bd4bfc7adadcef806596760fe"
 dependencies = [
  "bitflags 1.3.2",
- "cfg_aliases",
+ "cfg_aliases 0.1.1",
  "cgl",
  "core-foundation",
  "dispatch",
@@ -1663,7 +1669,7 @@ dependencies = [
  "kime-engine-core",
  "pad",
  "serde_yaml",
- "strum",
+ "strum 0.26.3",
  "xdg",
 ]
 
@@ -1671,11 +1677,11 @@ dependencies = [
 name = "kime-engine-backend"
 version = "0.1.0"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.10.0",
  "enum-map",
  "enumset",
  "serde",
- "strum",
+ "strum 0.27.2",
 ]
 
 [[package]]
@@ -1732,7 +1738,7 @@ name = "kime-engine-candidate"
 version = "0.1.0"
 dependencies = [
  "kime-engine-dict",
- "nix 0.26.4",
+ "nix 0.30.1",
 ]
 
 [[package]]
@@ -2033,15 +2039,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "memoffset"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2183,7 +2180,7 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
- "memoffset 0.6.5",
+ "memoffset",
 ]
 
 [[package]]
@@ -2196,20 +2193,7 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
- "memoffset 0.6.5",
-]
-
-[[package]]
-name = "nix"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "libc",
- "memoffset 0.7.1",
- "pin-utils",
+ "memoffset",
 ]
 
 [[package]]
@@ -2220,7 +2204,19 @@ checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
  "bitflags 2.10.0",
  "cfg-if",
- "cfg_aliases",
+ "cfg_aliases 0.1.1",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "cfg_aliases 0.2.1",
  "libc",
 ]
 
@@ -2598,12 +2594,6 @@ name = "pin-project-lite"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
@@ -3132,7 +3122,16 @@ version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros 0.27.2",
 ]
 
 [[package]]
@@ -3145,6 +3144,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
+ "syn 2.0.72",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
  "syn 2.0.72",
 ]
 

--- a/src/engine/backend/Cargo.toml
+++ b/src/engine/backend/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 license = "GPL-3.0-or-later"
 
 [dependencies]
-bitflags = "1.2.1"
+bitflags = "1.2"
 enum-map = "2"
-enumset = { version = "1", features = ["serde"] }
+enumset = { version = "1.1", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
-strum = { version = "0.24", features = ["derive"] }
+strum = { version = "0.26", features = ["derive"] }

--- a/src/engine/backend/Cargo.toml
+++ b/src/engine/backend/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 license = "GPL-3.0-or-later"
 
 [dependencies]
-bitflags = "1.2"
+bitflags = "2.10"
 enum-map = "2"
 enumset = { version = "1.1", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
-strum = { version = "0.26", features = ["derive"] }
+strum = { version = "0.27", features = ["derive"] }

--- a/src/engine/backend/src/input_result.rs
+++ b/src/engine/backend/src/input_result.rs
@@ -1,4 +1,5 @@
 bitflags::bitflags! {
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
     #[repr(transparent)]
     pub struct InputResult: u32 {
         const CONSUMED = 0b1;

--- a/src/engine/backend/src/keycode.rs
+++ b/src/engine/backend/src/keycode.rs
@@ -8,6 +8,7 @@ use serde::{
 use strum::{Display, EnumString};
 
 bitflags::bitflags! {
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
     #[repr(transparent)]
     pub struct ModifierState: u32 {
         const SHIFT = 0x1;

--- a/src/engine/backends/hangul/Cargo.toml
+++ b/src/engine/backends/hangul/Cargo.toml
@@ -7,11 +7,11 @@ license = "GPL-3.0-or-later"
 
 [dependencies]
 kime-engine-backend = { path = "../../backend" }
-enumset = "1.0.6"
-num-derive = "0.3.3"
-num-traits = "0.2.14"
-serde = { version = "1.0.124", features = ["derive"] }
+enumset = "1.1"
+num-derive = "0.4"
+num-traits = "0.2"
+serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
 
 [target.'cfg(unix)'.dependencies]
-xdg = "2.2.0"
+xdg = "2.5"

--- a/src/engine/candidate/Cargo.toml
+++ b/src/engine/candidate/Cargo.toml
@@ -9,4 +9,4 @@ license = "GPL-3.0-or-later"
 kime-engine-dict = { path = "../dict" }
 
 [dependencies]
-nix = "0.26.1"
+nix = "0.26"

--- a/src/engine/candidate/Cargo.toml
+++ b/src/engine/candidate/Cargo.toml
@@ -9,4 +9,4 @@ license = "GPL-3.0-or-later"
 kime-engine-dict = { path = "../dict" }
 
 [dependencies]
-nix = "0.26"
+nix = { version = "0.30", features = ["poll"] }

--- a/src/engine/candidate/src/client.rs
+++ b/src/engine/candidate/src/client.rs
@@ -1,14 +1,13 @@
-use nix::poll;
+use nix::poll::{self, PollFd, PollFlags, PollTimeout};
 use std::fmt;
 use std::io::{self, BufWriter, Write};
-use std::os::unix::io::{AsRawFd, RawFd};
+use std::os::unix::io::{AsFd, BorrowedFd};
 use std::process::{Child, Stdio};
 
 pub const CANDIDATE_PROCESS_NAME: &str = "kime-candidate-window";
 
 pub struct Client {
     child: Child,
-    stdout_fd: RawFd,
 }
 
 impl Client {
@@ -32,14 +31,13 @@ impl Client {
 
         drop(stdin);
 
-        let stdout_fd = child.stdout.as_ref().unwrap().as_raw_fd();
-
-        Ok(Self { stdout_fd, child })
+        Ok(Self { child })
     }
 
     pub fn is_ready(&self) -> bool {
-        let fds = &mut [poll::PollFd::new(self.stdout_fd, poll::PollFlags::POLLIN)];
-        poll::poll(fds, 200) == Ok(1)
+        let stdout: BorrowedFd = self.child.stdout.as_ref().unwrap().as_fd();
+        let fds = &mut [PollFd::new(stdout, PollFlags::POLLIN)];
+        poll::poll(fds, PollTimeout::from(200u16)) == Ok(1)
     }
 
     pub fn close(mut self) -> io::Result<Option<String>> {

--- a/src/engine/config/Cargo.toml
+++ b/src/engine/config/Cargo.toml
@@ -12,8 +12,8 @@ config-serde = ["serde", "enumset/serde", "log/serde"]
 kime-engine-backend = { path = "../backend" }
 kime-engine-backend-hangul = { path = "../backends/hangul" }
 kime-engine-backend-latin = { path = "../backends/latin" }
-log = "0.4.14"
-serde = { version = "1.0.124", features = ["derive"], optional = true }
-enumset = "1.0.6"
+log = "0.4"
+serde = { version = "1.0", features = ["derive"], optional = true }
+enumset = "1.1"
 enum-map = "2"
-maplit = "1.0.2"
+maplit = "1.0"

--- a/src/engine/core/Cargo.toml
+++ b/src/engine/core/Cargo.toml
@@ -15,15 +15,15 @@ kime-engine-backend-math = { path = "../backends/math", optional = true }
 kime-engine-backend-emoji = { path = "../backends/emoji", optional = true }
 serde_yaml = "0.9"
 parking_lot = "0.12"
-fontdb = { version = "0.11.2", features = ["fontconfig"] }
+fontdb = { version = "0.23", features = ["fontconfig"] }
 
 [target.'cfg(unix)'.dependencies]
-xdg = "2.2.0"
+xdg = "2.5"
 kime-run-dir = { path = "../../tools/run_dir" }
 
 [dev-dependencies]
-criterion = "0.4"
-pretty_assertions = "1.0.0"
+criterion = "0.8"
+pretty_assertions = "1.4"
 
 [[bench]]
 name = "call_key"

--- a/src/frontends/wayland/Cargo.toml
+++ b/src/frontends/wayland/Cargo.toml
@@ -17,8 +17,8 @@ wayland-protocols = { version = "0.29", features = [
 zwp-virtual-keyboard = "0.2.7"
 xkbcommon = { version = "0.7.0", features = ["wayland"] }
 
-libc = "0.2.82"
-log = "0.4.13"
-pico-args = "0.5.0"
+libc = "0.2"
+log = "0.4"
+pico-args = "0.5"
 mio = { version = "0.7", features = ["os-ext"] }
 mio-timerfd = "0.2"

--- a/src/frontends/xim/Cargo.toml
+++ b/src/frontends/xim/Cargo.toml
@@ -14,7 +14,7 @@ xim = { version = "0.2", default-features = false, features = ["x11rb-server"] }
 # xim = { path = "../../../../xim-rs", default-features = false, features = ["x11rb-server", "x11rb-xcb"] }
 
 ahash = "0.8"
-log = "0.4.11"
+log = "0.4"
 x11rb = { version = "0.11.0", features = [
     "render",
     "image",

--- a/src/tools/check/Cargo.toml
+++ b/src/tools/check/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "GPL-3.0-or-later"
 
 [dependencies]
-ansi_term = "0.12.1"
+owo-colors = "4"
 kime-engine-core = { path = "../../engine/core" }
 pad = "0.1.6"
 serde_yaml = "0.9"

--- a/src/tools/check/Cargo.toml
+++ b/src/tools/check/Cargo.toml
@@ -10,5 +10,5 @@ ansi_term = "0.12.1"
 kime-engine-core = { path = "../../engine/core" }
 pad = "0.1.6"
 serde_yaml = "0.9"
-strum = { version = "0.24", features = ["derive"] }
-xdg = "2.2.0"
+strum = { version = "0.26", features = ["derive"] }
+xdg = "2.5"

--- a/src/tools/check/src/main.rs
+++ b/src/tools/check/src/main.rs
@@ -1,7 +1,7 @@
 use kime_engine_core::{load_engine_config_from_config_dir, Key, KeyCode, KeyMap};
 
-use owo_colors::{OwoColorize, Style};
 use kime_engine_core::{Config, InputCategory, InputEngine, InputResult};
+use owo_colors::{OwoColorize, Style};
 use pad::PadStr;
 use std::env;
 use std::io::BufRead;

--- a/src/tools/check/src/main.rs
+++ b/src/tools/check/src/main.rs
@@ -1,6 +1,6 @@
 use kime_engine_core::{load_engine_config_from_config_dir, Key, KeyCode, KeyMap};
 
-use ansi_term::Color;
+use owo_colors::{OwoColorize, Style};
 use kime_engine_core::{Config, InputCategory, InputEngine, InputResult};
 use pad::PadStr;
 use std::env;
@@ -19,25 +19,25 @@ impl CondResult {
         matches!(self, Self::Ok | Self::Ignore(..))
     }
 
-    pub fn color(&self) -> Color {
+    pub fn style(&self) -> Style {
         match self {
-            CondResult::Ok => Color::Green,
-            CondResult::Fail(..) => Color::Red,
-            CondResult::Ignore(..) => Color::Purple,
+            CondResult::Ok => Style::new().green(),
+            CondResult::Fail(..) => Style::new().red(),
+            CondResult::Ignore(..) => Style::new().purple(),
         }
     }
 
     pub fn print(&self, message: &str) {
-        let c = self.color();
+        let s = self.style();
         print!(
             "{} {}",
-            c.paint(<&str>::from(self).pad_to_width(8)),
-            Color::White.bold().paint(message.pad_to_width(40))
+            <&str>::from(self).pad_to_width(8).style(s),
+            message.pad_to_width(40).bold().white()
         );
 
         match self {
             CondResult::Ok => println!(),
-            CondResult::Fail(msg) | CondResult::Ignore(msg) => println!("({})", c.paint(msg)),
+            CondResult::Fail(msg) | CondResult::Ignore(msg) => println!("({})", msg.style(s)),
         }
     }
 }

--- a/src/tools/indicator/Cargo.toml
+++ b/src/tools/indicator/Cargo.toml
@@ -10,7 +10,7 @@ kime-engine-core = { path = "../../engine/core" }
 kime-version = { path = "../version" }
 kime-run-dir = { path = "../run_dir" }
 
-anyhow = "1.0.38"
-pico-args = "0.5.0"
-log = "0.4.14"
-ksni = "0.2.0"
+anyhow = "1.0"
+pico-args = "0.5"
+log = "0.4"
+ksni = "0.2"

--- a/src/tools/kime/Cargo.toml
+++ b/src/tools/kime/Cargo.toml
@@ -11,6 +11,6 @@ kime-version = { path = "../version" }
 kime-run-dir = { path = "../run_dir" }
 
 ctrlc = { version = "3.4", features = ["termination"] }
-daemonize = "0.5"
+nix = { version = "0.30", features = ["process", "fs", "signal"] }
 log = "0.4"
 pico-args = "0.5"

--- a/src/tools/kime/Cargo.toml
+++ b/src/tools/kime/Cargo.toml
@@ -10,7 +10,7 @@ kime-engine-core = { path = "../../engine/core" }
 kime-version = { path = "../version" }
 kime-run-dir = { path = "../run_dir" }
 
-ctrlc = { version = "3.1.8", features = ["termination"] }
-daemonize = "0.5.0"
-log = "0.4.14"
-pico-args = "0.5.0"
+ctrlc = { version = "3.4", features = ["termination"] }
+daemonize = "0.5"
+log = "0.4"
+pico-args = "0.5"

--- a/src/tools/kime/src/main.rs
+++ b/src/tools/kime/src/main.rs
@@ -1,11 +1,13 @@
-use daemonize::Daemonize;
 use kime_engine_core::{load_raw_config_from_config_dir, DaemonModule as Module};
+use nix::unistd::{daemon, Pid};
+use nix::sys::signal::{kill, Signal};
+use std::os::unix::io::AsRawFd;
 use std::sync::atomic::{AtomicBool, Ordering::SeqCst};
 use std::{
-    env, io,
+    io,
     process::{Command, Stdio},
 };
-use std::{fs::File, path::Path};
+use std::{fs::File, io::Write, path::Path};
 
 const fn process_name(module: Module) -> &'static str {
     match module {
@@ -15,20 +17,18 @@ const fn process_name(module: Module) -> &'static str {
     }
 }
 
-fn kill_daemon(pid: &Path) -> io::Result<()> {
-    let pid = std::fs::read_to_string(pid)?;
+fn kill_daemon(pid_path: &Path) -> io::Result<()> {
+    let pid_str = std::fs::read_to_string(pid_path)?;
+    let pid: i32 = pid_str.trim().parse().map_err(|e| {
+        io::Error::new(io::ErrorKind::InvalidData, format!("Invalid PID: {}", e))
+    })?;
 
-    let ret = Command::new("kill")
-        .arg(pid)
-        .spawn()?
-        .wait_with_output()?
-        .status;
-
-    if ret.success() {
-        Ok(())
-    } else {
-        log::error!("kill return: {}", ret);
-        Err(io::Error::new(io::ErrorKind::Other, "kill command failed"))
+    match kill(Pid::from_raw(pid), Signal::SIGTERM) {
+        Ok(_) => Ok(()),
+        Err(err) => {
+            log::error!("kill return: {}", err);
+            Err(io::Error::new(io::ErrorKind::Other, "kill command failed"))
+        }
     }
 }
 
@@ -49,25 +49,35 @@ fn main() -> Result<(), ()> {
     }
 
     if !args.contains(["-D", "--no-daemon"]) {
-        let stderr = run_dir.join("kime.err");
-        let stderr_file = match File::create(stderr) {
+        let stderr_path = run_dir.join("kime.err");
+        let stderr_file = match File::create(&stderr_path) {
             Ok(file) => file,
             Err(err) => {
                 log::error!("Can't create stderr file: {}", err);
                 return Err(());
             }
         };
-        match Daemonize::new()
-            .working_directory("/tmp")
-            .stderr(stderr_file)
-            .pid_file(&pid)
-            .start()
-        {
+
+        // Daemonize: fork and detach from terminal (noclose=true to keep fds open)
+        match daemon(true, true) {
             Ok(_) => {}
             Err(err) => {
                 log::error!("Can't daemonize kime: {}", err);
                 return Err(());
             }
+        }
+
+        // Change working directory to /tmp
+        let _ = std::env::set_current_dir("/tmp");
+
+        // Redirect stderr to file
+        unsafe {
+            nix::libc::dup2(stderr_file.as_raw_fd(), nix::libc::STDERR_FILENO);
+        }
+
+        // Write PID file
+        if let Ok(mut file) = File::create(&pid) {
+            let _ = writeln!(file, "{}", std::process::id());
         }
     }
 

--- a/src/tools/kime/src/main.rs
+++ b/src/tools/kime/src/main.rs
@@ -1,4 +1,5 @@
 use kime_engine_core::{load_raw_config_from_config_dir, DaemonModule as Module};
+use nix::fcntl::{Flock, FlockArg};
 use nix::sys::signal::{kill, Signal};
 use nix::unistd::{daemon, Pid};
 use std::os::unix::io::AsRawFd;
@@ -19,10 +20,13 @@ const fn process_name(module: Module) -> &'static str {
 
 fn kill_daemon(pid_path: &Path) -> io::Result<()> {
     let pid_str = std::fs::read_to_string(pid_path)?;
-    let pid: i32 = pid_str
-        .trim()
-        .parse()
-        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, format!("Invalid PID: {}", e)))?;
+    let pid: i32 = match pid_str.trim().parse() {
+        Ok(pid) => pid,
+        Err(err) => {
+            log::error!("kill return: {}", err);
+            return Err(io::Error::new(io::ErrorKind::Other, "kill command failed"));
+        }
+    };
 
     match kill(Pid::from_raw(pid), Signal::SIGTERM) {
         Ok(_) => Ok(()),
@@ -75,12 +79,28 @@ fn main() -> Result<(), ()> {
         unsafe {
             nix::libc::dup2(stderr_file.as_raw_fd(), nix::libc::STDERR_FILENO);
         }
-
-        // Write PID file
-        if let Ok(mut file) = File::create(&pid) {
-            let _ = writeln!(file, "{}", std::process::id());
-        }
     }
+
+    // Create PID file and lock it exclusively to prevent duplicate instances
+    // Lock must be held until program exits (like daemonize library behavior)
+    // Possible errors:
+    //   - File::create fails: permission denied, disk full, etc.
+    //   - Flock::lock returns EWOULDBLOCK: another kime instance is running
+    //   - Flock::lock returns other error: unexpected lock failure
+    let _pid_lock = match File::create(&pid).and_then(|file| {
+        Flock::lock(file, FlockArg::LockExclusiveNonblock).map_err(|(_, e)| io::Error::from(e))
+    }) {
+        Ok(mut lock) => {
+            writeln!(lock, "{}", std::process::id()).map_err(|err| {
+                log::error!("Can't daemonize kime: {}", err);
+            })?;
+            Some(lock)
+        }
+        Err(err) => {
+            log::error!("Can't daemonize kime: {}", err);
+            return Err(());
+        }
+    };
 
     let config = load_raw_config_from_config_dir().daemon;
 

--- a/src/tools/kime/src/main.rs
+++ b/src/tools/kime/src/main.rs
@@ -96,6 +96,10 @@ fn main() -> Result<(), ()> {
             })?;
             Some(lock)
         }
+        Err(err) if err.kind() == io::ErrorKind::WouldBlock => {
+            log::error!("Another instance of kime daemon is already running.");
+            return Err(());
+        }
         Err(err) => {
             log::error!("Can't daemonize kime: {}", err);
             return Err(());

--- a/src/tools/kime/src/main.rs
+++ b/src/tools/kime/src/main.rs
@@ -1,13 +1,13 @@
 use kime_engine_core::{load_raw_config_from_config_dir, DaemonModule as Module};
-use nix::unistd::{daemon, Pid};
 use nix::sys::signal::{kill, Signal};
+use nix::unistd::{daemon, Pid};
 use std::os::unix::io::AsRawFd;
 use std::sync::atomic::{AtomicBool, Ordering::SeqCst};
+use std::{fs::File, io::Write, path::Path};
 use std::{
     io,
     process::{Command, Stdio},
 };
-use std::{fs::File, io::Write, path::Path};
 
 const fn process_name(module: Module) -> &'static str {
     match module {
@@ -19,9 +19,10 @@ const fn process_name(module: Module) -> &'static str {
 
 fn kill_daemon(pid_path: &Path) -> io::Result<()> {
     let pid_str = std::fs::read_to_string(pid_path)?;
-    let pid: i32 = pid_str.trim().parse().map_err(|e| {
-        io::Error::new(io::ErrorKind::InvalidData, format!("Invalid PID: {}", e))
-    })?;
+    let pid: i32 = pid_str
+        .trim()
+        .parse()
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, format!("Invalid PID: {}", e)))?;
 
     match kill(Pid::from_raw(pid), Signal::SIGTERM) {
         Ok(_) => Ok(()),


### PR DESCRIPTION
## Summary
update rust crates version and modify some code about package recommends

## Note
Simple update and replace crates packages (like out of support), major upgraded crates need to fix some codes.
간단한 crates 버전들 업데이트 및 변경(메인테이넌스 중단된 것들)하고, 메이저 버전 올라간 것들은 그에 맞춰 코드 수정해봤습니다.

- kime-check: ansi_term → owo-colors
- kime: daemonize → nix::unistd::daemon()
- bitflags 1.2 → 2.10: add explicit derive macros
- nix 0.26 → 0.30: migrate RawFd to BorrowedFd
- strum 0.26 → 0.27
- enumset 1.0 → 1.1
- num-derive 0.3 → 0.4
- xdg 2.2 → 2.5
- ctrlc 3.1 → 3.4
- fontdb 0.11 → 0.23
- criterion 0.4 → 0.8
- pretty_assertions 1.0 → 1.4
- Normalize version format in Cargo.toml files

## Checklist

- [ ] I have documented my changes properly to adequate places
- [ ] I have updated the docs/CHANGELOG.md
