### PR TITLE
fix(wayland): bypass key events when input not activated

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,6 +30,7 @@
 * Fix kime-wayland crash on KDE Plasma 6.5.5 by handling KeyState::Repeated
 * Fix indicator tray icon not showing/updating on KDE with tokio async I/O (ksni 0.3.3)
 * Rewrite kime-wayland for wayland-rs 0.31 API (Dispatch trait pattern)
+* Fix kime-wayland not bypassing key events when input not activated [#744](https://github.com/Riey/kime/issues/744)
 
 
 ## 3.1.1

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,7 +30,6 @@
 * Fix kime-wayland crash on KDE Plasma 6.5.5 by handling KeyState::Repeated
 * Fix indicator tray icon not showing/updating on KDE with tokio async I/O (ksni 0.3.3)
 * Rewrite kime-wayland for wayland-rs 0.31 API (Dispatch trait pattern)
-* Fix kime-wayland not bypassing key events when input not activated [#744](https://github.com/Riey/kime/issues/744)
 
 
 ## 3.1.1

--- a/src/frontends/wayland/src/state.rs
+++ b/src/frontends/wayland/src/state.rs
@@ -674,17 +674,16 @@ impl Dispatch<ZwpInputMethodKeyboardGrabV2, ()> for AppState {
                     } else if let Some(ref im_state) = state.im_v2 {
                         im_state.vk.key(time, key, key_state.into());
                     }
-                } else if matches!(key_state, WEnum::Value(KeyState::Released)) {
-                    if let Some((.., ref mut press_state)) = state.repeat_state {
-                        if press_state.is_pressing(key) {
-                            let _ = state.timer.set_timeout_oneshot(Duration::ZERO);
-                            *press_state = PressState::NotPressing;
+                } else {
+                    // Not activated or Released - bypass all keys
+                    if matches!(key_state, WEnum::Value(KeyState::Released)) {
+                        if let Some((.., ref mut press_state)) = state.repeat_state {
+                            if press_state.is_pressing(key) {
+                                let _ = state.timer.set_timeout_oneshot(Duration::ZERO);
+                                *press_state = PressState::NotPressing;
+                            }
                         }
                     }
-                    if let Some(ref im_state) = state.im_v2 {
-                        im_state.vk.key(time, key, key_state.into());
-                    }
-                } else if !is_pressed {
                     if let Some(ref im_state) = state.im_v2 {
                         im_state.vk.key(time, key, key_state.into());
                     }
@@ -894,16 +893,19 @@ impl Dispatch<WlKeyboard, ()> for AppState {
                     } else if let WEnum::Value(ks) = key_state {
                         state.key_v1(time, key, ks);
                     }
-                } else if matches!(key_state, WEnum::Value(KeyState::Released)) {
-                    if let Some((.., ref mut press_state)) = state.repeat_state {
-                        if press_state.is_pressing(key) {
-                            let _ = state.timer.set_timeout_oneshot(Duration::ZERO);
-                            *press_state = PressState::NotPressing;
+                } else {
+                    // Not activated or Released - bypass all keys
+                    if matches!(key_state, WEnum::Value(KeyState::Released)) {
+                        if let Some((.., ref mut press_state)) = state.repeat_state {
+                            if press_state.is_pressing(key) {
+                                let _ = state.timer.set_timeout_oneshot(Duration::ZERO);
+                                *press_state = PressState::NotPressing;
+                            }
                         }
                     }
-                    state.key_v1(time, key, KeyState::Released);
-                } else if let WEnum::Value(ks) = key_state {
-                    state.key_v1(time, key, ks);
+                    if let WEnum::Value(ks) = key_state {
+                        state.key_v1(time, key, ks);
+                    }
                 }
             }
             wl_keyboard::Event::Modifiers {

--- a/src/frontends/wayland/src/state.rs
+++ b/src/frontends/wayland/src/state.rs
@@ -674,16 +674,18 @@ impl Dispatch<ZwpInputMethodKeyboardGrabV2, ()> for AppState {
                     } else if let Some(ref im_state) = state.im_v2 {
                         im_state.vk.key(time, key, key_state.into());
                     }
-                } else {
-                    // Not activated or Released - bypass all keys
-                    if matches!(key_state, WEnum::Value(KeyState::Released)) {
-                        if let Some((.., ref mut press_state)) = state.repeat_state {
-                            if press_state.is_pressing(key) {
-                                let _ = state.timer.set_timeout_oneshot(Duration::ZERO);
-                                *press_state = PressState::NotPressing;
-                            }
+                } else if matches!(key_state, WEnum::Value(KeyState::Released)) {
+                    if let Some((.., ref mut press_state)) = state.repeat_state {
+                        if press_state.is_pressing(key) {
+                            let _ = state.timer.set_timeout_oneshot(Duration::ZERO);
+                            *press_state = PressState::NotPressing;
                         }
                     }
+                    if let Some(ref im_state) = state.im_v2 {
+                        im_state.vk.key(time, key, key_state.into());
+                    }
+                } else {
+                    // is_pressed && !grab_activate - bypass
                     if let Some(ref im_state) = state.im_v2 {
                         im_state.vk.key(time, key, key_state.into());
                     }
@@ -893,19 +895,19 @@ impl Dispatch<WlKeyboard, ()> for AppState {
                     } else if let WEnum::Value(ks) = key_state {
                         state.key_v1(time, key, ks);
                     }
-                } else {
-                    // Not activated or Released - bypass all keys
-                    if matches!(key_state, WEnum::Value(KeyState::Released)) {
-                        if let Some((.., ref mut press_state)) = state.repeat_state {
-                            if press_state.is_pressing(key) {
-                                let _ = state.timer.set_timeout_oneshot(Duration::ZERO);
-                                *press_state = PressState::NotPressing;
-                            }
+                } else if matches!(key_state, WEnum::Value(KeyState::Released)) {
+                    if let Some((.., ref mut press_state)) = state.repeat_state {
+                        if press_state.is_pressing(key) {
+                            let _ = state.timer.set_timeout_oneshot(Duration::ZERO);
+                            *press_state = PressState::NotPressing;
                         }
                     }
                     if let WEnum::Value(ks) = key_state {
                         state.key_v1(time, key, ks);
                     }
+                } else if let WEnum::Value(ks) = key_state {
+                    // is_pressed && !grab_activate - bypass
+                    state.key_v1(time, key, ks);
                 }
             }
             wl_keyboard::Event::Modifiers {


### PR DESCRIPTION
## Summary
When grab_activate is false, key press events were not being forwarded to the compositor, causing shortcuts and input to stop working in apps like Firefox, rofi, hyprlock, wlogout on wlroots-based compositors (Niri, Hyprland).

## Note
Fixes key handling to match previous behavior:
- V2: forward all keys via vk.key() when not activated
- V1: forward all keys via key_v1() when not activated

## Checklist

- [X] I have documented my changes properly to adequate places
- [X] I have updated the docs/CHANGELOG.md
