### PR TITLE
ci(release): build qt6 per-version like qt5, add Qt 6.9/6.10

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Build
         run: |
           nix develop -c meson setup build \
-            -Dgtk3=enabled -Dgtk4=enabled -Dqt5=disabled -Dqt6=enabled
+            -Dgtk3=enabled -Dgtk4=enabled -Dqt5=disabled -Dqt6=disabled
           nix develop -c ninja -C build
 
       - name: Strip
@@ -102,7 +102,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        qt6: ['6.2.4', '6.5.3', '6.7.3', '6.8.2']
+        qt6: ['6.2.4', '6.5.3', '6.7.3', '6.8.2', '6.9.3', '6.10.3']
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
Treat the qt6 immodule the same way as qt5 in the release pipeline, and extend the per-version Qt6 build matrix.

- **build-archive**: `-Dqt6=disabled`. The qt6 plugin is built against Qt's private QPA API and is version-sensitive, so (like qt5) it should ship as per-version artifacts from the `build-qt6` matrix rather than a single build bundled into the generic tarball.
- **build-qt6 matrix**: add `6.9.3` and `6.10.3` (both installable via `install-qt-action@v4` / aqtinstall).

## Notes
qt6 is still delivered to users via the per-version `libkime-qt-<version>.so` release artifacts — only its inclusion in the generic archive changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FT8zVKCvTRgZiMLPpNw8Hs
