### PR TITLE
ci(release): enable gtk4+qt6 immodules for ubuntu-22.04 deb

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -149,9 +149,9 @@ jobs:
         include:
           - container: ubuntu:22.04
             gtk3: enabled
-            gtk4: disabled
+            gtk4: enabled
             qt5: enabled
-            qt6: disabled
+            qt6: enabled
             suffix: ubuntu-22.04
           - container: ubuntu:24.04
             gtk3: enabled


### PR DESCRIPTION
## Summary
Enable the gtk4 and qt6 immodules in the Ubuntu 22.04 .deb build (follow-up to #749 / #734).

Ubuntu 22.04 (jammy) ships the needed dev packages — `libgtk-4-dev` (4.6.9) and `qt6-base-dev` / `qt6-base-private-dev` (6.2.4) — in its archives (universe). Qt 6.2.4 already builds in the `build-qt6` matrix and the gtk4 code path uses only GTK4 4.0 APIs, so the 22.04 deb can include both immodules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FT8zVKCvTRgZiMLPpNw8Hs
