### PR TITLE
feat(ibus): add kime-ibus IBus engine frontend (#422, #748)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,9 +285,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "calloop"
@@ -718,12 +718,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.5"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
-dependencies = [
- "powerfmt",
-]
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
 name = "diff"
@@ -1643,9 +1640,9 @@ dependencies = [
 
 [[package]]
 name = "imageproc"
-version = "0.26.0"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3880a67ffee492100224b2ff31f4220ade971fc327c3c96faa63095a3825ea4d"
+checksum = "645329c490783f3ea465d2b6c7c08286fece97f15e714fd533b6c70a3ead2252"
 dependencies = [
  "ab_glyph",
  "approx",
@@ -1894,6 +1891,18 @@ dependencies = [
  "serde",
  "serde_json",
  "unicode-properties",
+]
+
+[[package]]
+name = "kime-ibus"
+version = "0.1.0"
+dependencies = [
+ "kime-engine-core",
+ "kime-version",
+ "log",
+ "pico-args",
+ "tokio",
+ "zbus",
 ]
 
 [[package]]
@@ -2276,9 +2285,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-derive"
@@ -3553,12 +3562,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.45"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
 dependencies = [
  "deranged",
- "itoa",
  "libc",
  "num-conv",
  "num_threads",
@@ -3570,15 +3578,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.7"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.25"
+version = "0.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
+checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
 dependencies = [
  "num-conv",
  "time-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "src/engine/backends/latin",
     "src/engine/backends/math",
 
+    "src/frontends/ibus",
     "src/frontends/wayland",
     "src/frontends/xim",
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### Improve
 
+* Add `kime-ibus` IBus engine frontend (preedit + commit + key/focus/reset). This
+  is the supported path on GNOME Wayland where Mutter lacks `zwp_input_method_v2`
+  [#422](https://github.com/Riey/kime/issues/422) [#748](https://github.com/Riey/kime/issues/748)
 * Replace cmake build system with meson
   - cargo builds via `custom_target()`, GTK/Qt frontends as `shared_library()`
   - Per-component build options (gtk3, gtk4, qt5, qt6, check, indicator, etc.), enabled by default

--- a/meson.build
+++ b/meson.build
@@ -49,6 +49,9 @@ else
   if get_option('wayland').allowed()
     cargo_packages += ['-p', 'kime-wayland']
   endif
+  if get_option('ibus').allowed()
+    cargo_packages += ['-p', 'kime-ibus']
+  endif
   # kime main binary is always built when not using system engine
   cargo_packages += ['-p', 'kime']
 
@@ -103,6 +106,12 @@ else
       '_', target_dir / 'kime-wayland',
     )
   endif
+  if get_option('ibus').allowed()
+    meson.add_install_script('sh', '-c',
+      'install -Dm755 "$1" -t "${DESTDIR}${MESON_INSTALL_PREFIX}/bin"',
+      '_', target_dir / 'kime-ibus',
+    )
+  endif
 
   # Install engine shared library
   meson.add_install_script('sh', '-c',
@@ -136,6 +145,13 @@ meson.add_install_script('sh', '-c',
   'install -Dm755 "$1" -t "${DESTDIR}${MESON_INSTALL_PREFIX}/bin"',
   '_', meson.project_source_root() / 'res' / 'kime-xdg-autostart',
 )
+
+# Install IBus component definition (makes "kime" selectable in IBus/GNOME)
+if get_option('ibus').allowed()
+  install_data('res/ibus/component/kime.xml',
+    install_dir: get_option('datadir') / 'ibus' / 'component',
+  )
+endif
 
 # Install icons
 install_data(

--- a/meson.options
+++ b/meson.options
@@ -9,6 +9,7 @@ option('indicator', type: 'feature', value: 'auto', description: 'Build kime-ind
 option('candidate_window', type: 'feature', value: 'auto', description: 'Build kime-candidate-window')
 option('xim', type: 'feature', value: 'auto', description: 'Build kime-xim')
 option('wayland', type: 'feature', value: 'auto', description: 'Build kime-wayland')
+option('ibus', type: 'feature', value: 'auto', description: 'Build kime-ibus IBus engine')
 
 option('install_headers', type: 'boolean', value: true, description: 'Install C/C++ headers')
 option('install_docs', type: 'boolean', value: true, description: 'Install documentation')

--- a/res/ibus/component/kime.xml
+++ b/res/ibus/component/kime.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Installed to ${datadir}/ibus/component/kime.xml -->
+<component>
+  <name>org.freedesktop.IBus.Kime</name>
+  <description>Kime Korean input method</description>
+  <exec>/usr/bin/kime-ibus --ibus</exec>
+  <version>3.1.1</version>
+  <author>Riey &lt;creeper844@gmail.com&gt;</author>
+  <license>GPL-3.0</license>
+  <homepage>https://github.com/Riey/kime</homepage>
+  <textdomain>kime</textdomain>
+
+  <engines>
+    <engine>
+      <name>kime</name>
+      <longname>Kime</longname>
+      <description>Kime Korean input method</description>
+      <language>ko</language>
+      <license>GPL-3.0</license>
+      <author>Riey &lt;creeper844@gmail.com&gt;</author>
+      <layout>us</layout>
+      <rank>99</rank>
+      <symbol>한</symbol>
+    </engine>
+  </engines>
+</component>

--- a/src/frontends/ibus/Cargo.toml
+++ b/src/frontends/ibus/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "kime-ibus"
+description = "Kime IBus engine"
+version = "0.1.0"
+authors = ["Riey <creeper844@gmail.com>"]
+edition = "2021"
+license = "GPL-3.0-or-later"
+
+[dependencies]
+kime-engine-core = { path = "../../engine/core" }
+kime-version = { path = "../../tools/version" }
+
+# IBus is a D-Bus protocol; talk to it directly with zbus (pure Rust).
+# `default-features = false` + `tokio` makes zbus use the tokio runtime that
+# is already present in the workspace (via ksni). Run under `#[tokio::main]`.
+zbus = { version = "5", default-features = false, features = ["tokio"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+
+log = "0.4"
+pico-args = "0.5"

--- a/src/frontends/ibus/src/connection.rs
+++ b/src/frontends/ibus/src/connection.rs
@@ -1,0 +1,114 @@
+//! IBus bus discovery and connection bootstrap.
+//!
+//! IBus is a private D-Bus bus. We discover its address (preferring the
+//! `IBUS_ADDRESS` env var the daemon sets when it launches us, falling back to
+//! the per-session socket file), connect with zbus, request the well-known name
+//! `org.freedesktop.IBus.Kime`, and serve the factory object.
+
+use std::error::Error;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use kime_engine_core::load_engine_config_from_config_dir;
+
+use crate::factory::IBusFactory;
+
+const WELL_KNOWN_NAME: &str = "org.freedesktop.IBus.Kime";
+const FACTORY_PATH: &str = "/org/freedesktop/IBus/Factory";
+
+/// Connect to the IBus daemon, register the factory and run until disconnect.
+pub async fn run() -> Result<(), Box<dyn Error>> {
+    let address = get_ibus_address()?;
+    log::info!("Connecting to IBus at {}", address);
+
+    let conn = zbus::connection::Builder::address(address.as_str())?
+        .build()
+        .await?;
+
+    let config = Arc::new(load_engine_config_from_config_dir().unwrap_or_default());
+
+    let factory = IBusFactory::new(conn.clone(), config);
+    conn.object_server().at(FACTORY_PATH, factory).await?;
+
+    conn.request_name(WELL_KNOWN_NAME).await?;
+    log::info!(
+        "Registered {} and factory at {}",
+        WELL_KNOWN_NAME,
+        FACTORY_PATH
+    );
+
+    // The object server runs on zbus's internal tasks; keep the process alive so
+    // it can serve method calls. ibus-daemon will respawn us as needed.
+    std::future::pending::<()>().await;
+
+    Ok(())
+}
+
+/// Discover the IBus bus address.
+fn get_ibus_address() -> Result<String, Box<dyn Error>> {
+    if let Ok(addr) = std::env::var("IBUS_ADDRESS") {
+        if !addr.is_empty() {
+            return Ok(addr);
+        }
+    }
+
+    let path = socket_file_path()?;
+    log::debug!("Reading IBus address from {}", path.display());
+    let content = std::fs::read_to_string(&path)?;
+    for line in content.lines() {
+        if let Some(rest) = line.strip_prefix("IBUS_ADDRESS=") {
+            return Ok(rest.trim().to_string());
+        }
+    }
+
+    Err(format!("IBUS_ADDRESS not found in {}", path.display()).into())
+}
+
+/// `$XDG_CONFIG_HOME/ibus/bus/<machine-id>-<host>-<display>` (or `~/.config/...`).
+fn socket_file_path() -> Result<PathBuf, Box<dyn Error>> {
+    let machine_id = read_machine_id()?;
+    let (host, display) = display_parts();
+
+    let config_dir = std::env::var_os("XDG_CONFIG_HOME")
+        .map(PathBuf::from)
+        .filter(|p| !p.as_os_str().is_empty())
+        .or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".config")))
+        .ok_or("Neither XDG_CONFIG_HOME nor HOME is set")?;
+
+    Ok(config_dir
+        .join("ibus")
+        .join("bus")
+        .join(format!("{machine_id}-{host}-{display}")))
+}
+
+fn read_machine_id() -> Result<String, Box<dyn Error>> {
+    for path in ["/etc/machine-id", "/var/lib/dbus/machine-id"] {
+        if let Ok(content) = std::fs::read_to_string(path) {
+            let id = content.trim();
+            if !id.is_empty() {
+                return Ok(id.to_string());
+            }
+        }
+    }
+    Err("Could not read machine-id".into())
+}
+
+/// Parse `$DISPLAY` into the host/display-number components IBus uses for its
+/// socket file name. For `:0` this yields `("unix", "0")`.
+fn display_parts() -> (String, String) {
+    let display = std::env::var("DISPLAY").unwrap_or_default();
+    match display.rsplit_once(':') {
+        Some((host, tail)) => {
+            let host = if host.is_empty() {
+                "unix".to_string()
+            } else {
+                host.to_string()
+            };
+            let number = tail.split('.').next().unwrap_or("0").to_string();
+            (host, number)
+        }
+        // No DISPLAY (e.g. pure Wayland session): the env-var path is normally
+        // used instead, but fall back to the common default.
+        None => ("unix".to_string(), "0".to_string()),
+    }
+}

--- a/src/frontends/ibus/src/engine.rs
+++ b/src/frontends/ibus/src/engine.rs
@@ -1,0 +1,285 @@
+//! `org.freedesktop.IBus.Engine` implementation.
+//!
+//! One [`IBusEngine`] instance is served per IBus input context (created by the
+//! factory's `CreateEngine`). It owns its own [`InputEngine`] and shares the
+//! loaded [`Config`] through an `Arc`.
+//!
+//! The key/preedit/commit logic mirrors the xim and wayland frontends exactly:
+//! we feed the X11 hardware keycode to [`InputEngine::press_key_code`] and act on
+//! the returned [`InputResult`] bitflags.
+
+use std::sync::Arc;
+
+use kime_engine_core::{Config, InputEngine, InputResult, ModifierState};
+use zbus::{interface, zvariant::Value, Connection};
+
+use crate::ibus_types::ibus_text;
+
+/// IBus modifier mask bits (from `ibustypes.h`). These mirror the X11 modifier
+/// masks that IBus forwards in `ProcessKeyEvent`'s `state` argument.
+const IBUS_SHIFT_MASK: u32 = 1 << 0;
+const IBUS_CONTROL_MASK: u32 = 1 << 2;
+const IBUS_MOD1_MASK: u32 = 1 << 3; // Alt
+const IBUS_MOD2_MASK: u32 = 1 << 4; // NumLock
+const IBUS_MOD4_MASK: u32 = 1 << 6; // commonly the physical Super key
+const IBUS_SUPER_MASK: u32 = 1 << 26; // virtual Super modifier
+const IBUS_RELEASE_MASK: u32 = 1 << 30;
+
+const ENGINE_INTERFACE: &str = "org.freedesktop.IBus.Engine";
+
+pub struct IBusEngine {
+    engine: InputEngine,
+    config: Arc<Config>,
+    conn: Connection,
+    /// D-Bus object path this engine is served at; used as the signal sender path.
+    path: String,
+    engine_ready: bool,
+    /// Byte length of the last preedit we sent, so we only emit a "hide" once.
+    last_preedit_len: usize,
+}
+
+impl IBusEngine {
+    pub fn new(conn: Connection, path: String, config: Arc<Config>) -> Self {
+        Self {
+            engine: InputEngine::new(&config),
+            config,
+            conn,
+            path,
+            engine_ready: true,
+            last_preedit_len: 0,
+        }
+    }
+
+    async fn commit_text(&self, text: &str) {
+        let v = ibus_text(text);
+        if let Err(e) = self
+            .conn
+            .emit_signal(
+                None::<&str>,
+                self.path.as_str(),
+                ENGINE_INTERFACE,
+                "CommitText",
+                &(v,),
+            )
+            .await
+        {
+            log::warn!("Failed to emit CommitText: {}", e);
+        }
+    }
+
+    async fn update_preedit(&self, text: &str, cursor_pos: u32, visible: bool) {
+        let v = ibus_text(text);
+        if let Err(e) = self
+            .conn
+            .emit_signal(
+                None::<&str>,
+                self.path.as_str(),
+                ENGINE_INTERFACE,
+                "UpdatePreeditText",
+                &(v, cursor_pos, visible),
+            )
+            .await
+        {
+            log::warn!("Failed to emit UpdatePreeditText: {}", e);
+        }
+    }
+
+    async fn hide_preedit(&self) {
+        if let Err(e) = self
+            .conn
+            .emit_signal(
+                None::<&str>,
+                self.path.as_str(),
+                ENGINE_INTERFACE,
+                "HidePreeditText",
+                &(),
+            )
+            .await
+        {
+            log::warn!("Failed to emit HidePreeditText: {}", e);
+        }
+    }
+
+    /// Interpret an [`InputResult`] the same way xim/wayland do and emit the
+    /// matching IBus signals. Returns whether the key was CONSUMED.
+    async fn process_result(&mut self, ret: InputResult) -> bool {
+        log::trace!("InputResult: {:?}", ret);
+
+        if ret.contains(InputResult::LANGUAGE_CHANGED) {
+            self.engine.update_layout_state().ok();
+        }
+
+        // Commit finalized text first, then show the new preedit (matches xim).
+        if ret.contains(InputResult::HAS_COMMIT) {
+            let commit = self.engine.commit_str().to_string();
+            if !commit.is_empty() {
+                self.commit_text(&commit).await;
+            }
+            self.engine.clear_commit();
+        }
+
+        if ret.contains(InputResult::HAS_PREEDIT) {
+            let preedit = self.engine.preedit_str().to_string();
+            let cursor = preedit.chars().count() as u32;
+            self.update_preedit(&preedit, cursor, true).await;
+            self.last_preedit_len = preedit.len();
+        } else if self.last_preedit_len > 0 {
+            self.update_preedit("", 0, false).await;
+            self.hide_preedit().await;
+            self.last_preedit_len = 0;
+        }
+
+        self.engine_ready = !ret.contains(InputResult::NOT_READY);
+
+        ret.contains(InputResult::CONSUMED)
+    }
+
+    /// Flush and clear the engine, mirroring `KimeHandler::reset` in the xim
+    /// frontend: the in-progress syllable is finalized into a commit.
+    async fn reset_engine(&mut self) {
+        self.engine.clear_preedit();
+        let commit = self.engine.commit_str().to_string();
+        if !commit.is_empty() {
+            self.commit_text(&commit).await;
+        }
+        if self.last_preedit_len > 0 {
+            self.update_preedit("", 0, false).await;
+            self.hide_preedit().await;
+            self.last_preedit_len = 0;
+        }
+        self.engine.reset();
+    }
+
+    /// Shared focus-in/enable logic: refresh the global layout state and flush a
+    /// pending "ready" result (math/emoji modes) if one is now available.
+    async fn on_focus_in(&mut self) {
+        self.engine.update_layout_state().ok();
+        if !self.engine_ready && self.engine.check_ready() {
+            let ret = self.engine.end_ready();
+            self.process_result(ret).await;
+            self.engine_ready = true;
+        }
+    }
+}
+
+#[interface(name = "org.freedesktop.IBus.Engine")]
+impl IBusEngine {
+    /// Process a key event. Returns `true` when kime consumed the key (the
+    /// application must not receive it), `false` to let the application get it.
+    async fn process_key_event(&mut self, _keyval: u32, keycode: u32, state: u32) -> bool {
+        // Only handle key presses; releases carry IBUS_RELEASE_MASK.
+        if state & IBUS_RELEASE_MASK != 0 {
+            return false;
+        }
+
+        let mut mods = ModifierState::empty();
+        if state & IBUS_SHIFT_MASK != 0 {
+            mods |= ModifierState::SHIFT;
+        }
+        if state & IBUS_CONTROL_MASK != 0 {
+            mods |= ModifierState::CONTROL;
+        }
+        if state & IBUS_MOD1_MASK != 0 {
+            mods |= ModifierState::ALT;
+        }
+        if state & (IBUS_SUPER_MASK | IBUS_MOD4_MASK) != 0 {
+            mods |= ModifierState::SUPER;
+        }
+        let numlock = state & IBUS_MOD2_MASK != 0;
+
+        // IBus `keycode` is the X11 hardware keycode (evdev + 8), which is what
+        // kime's keycode table expects as the hardware code.
+        let ret = self
+            .engine
+            .press_key_code(keycode as u16, mods, numlock, &self.config);
+        self.process_result(ret).await
+    }
+
+    async fn focus_in(&mut self) {
+        log::trace!("FocusIn");
+        self.on_focus_in().await;
+    }
+
+    async fn focus_out(&mut self) {
+        log::trace!("FocusOut");
+        if self.engine_ready {
+            self.reset_engine().await;
+        }
+    }
+
+    /// Newer focus signals (IBUS_CAP_FOCUS_ID). Same behavior as FocusIn/Out.
+    async fn focus_in_id(&mut self, _object_path: String, _client: String) {
+        log::trace!("FocusInId");
+        self.on_focus_in().await;
+    }
+
+    async fn focus_out_id(&mut self, _object_path: String) {
+        log::trace!("FocusOutId");
+        if self.engine_ready {
+            self.reset_engine().await;
+        }
+    }
+
+    async fn enable(&mut self) {
+        log::trace!("Enable");
+        self.on_focus_in().await;
+    }
+
+    async fn disable(&mut self) {
+        log::trace!("Disable");
+        self.reset_engine().await;
+    }
+
+    async fn reset(&mut self) {
+        log::trace!("Reset");
+        self.reset_engine().await;
+    }
+
+    async fn destroy(&mut self) {
+        log::info!("Destroy engine at {}", self.path);
+        self.reset_engine().await;
+
+        // Remove ourselves from the object server. Do it from a spawned task to
+        // avoid re-entrant locking while this method still holds the interface.
+        let conn = self.conn.clone();
+        let path = self.path.clone();
+        tokio::spawn(async move {
+            if let Err(e) = conn
+                .object_server()
+                .remove::<IBusEngine, _>(path.as_str())
+                .await
+            {
+                log::warn!("Failed to remove engine {}: {}", path, e);
+            }
+        });
+    }
+
+    // --- No-op stubs for the rest of the interface the daemon may call. ---
+    // Their argument signatures must match IBus so the calls demarshal cleanly.
+
+    fn set_cursor_location(&mut self, _x: i32, _y: i32, _w: i32, _h: i32) {}
+
+    fn set_cursor_location_relative(&mut self, _x: i32, _y: i32, _w: i32, _h: i32) {}
+
+    fn set_capabilities(&mut self, _caps: u32) {}
+
+    fn set_content_type(&mut self, _purpose: u32, _hints: u32) {}
+
+    fn set_surrounding_text(&mut self, _text: Value<'_>, _cursor_pos: u32, _anchor_pos: u32) {}
+
+    fn property_activate(&mut self, _name: String, _state: u32) {}
+
+    fn property_show(&mut self, _name: String) {}
+
+    fn property_hide(&mut self, _name: String) {}
+
+    fn candidate_clicked(&mut self, _index: u32, _button: u32, _state: u32) {}
+
+    fn page_up(&mut self) {}
+
+    fn page_down(&mut self) {}
+
+    fn cursor_up(&mut self) {}
+
+    fn cursor_down(&mut self) {}
+}

--- a/src/frontends/ibus/src/factory.rs
+++ b/src/frontends/ibus/src/factory.rs
@@ -1,0 +1,49 @@
+//! `org.freedesktop.IBus.Factory` implementation.
+//!
+//! The factory is served at `/org/freedesktop/IBus/Factory`. When the daemon
+//! activates the engine it calls `CreateEngine`, for which we spin up a new
+//! [`IBusEngine`] object served at a unique path and return that path.
+
+use std::sync::Arc;
+
+use kime_engine_core::Config;
+use zbus::{interface, zvariant::OwnedObjectPath, Connection};
+
+use crate::engine::IBusEngine;
+
+pub struct IBusFactory {
+    conn: Connection,
+    config: Arc<Config>,
+    next_id: u64,
+}
+
+impl IBusFactory {
+    pub fn new(conn: Connection, config: Arc<Config>) -> Self {
+        Self {
+            conn,
+            config,
+            next_id: 0,
+        }
+    }
+}
+
+#[interface(name = "org.freedesktop.IBus.Factory")]
+impl IBusFactory {
+    async fn create_engine(&mut self, engine_name: String) -> zbus::fdo::Result<OwnedObjectPath> {
+        let id = self.next_id;
+        self.next_id += 1;
+        let path = format!("/org/freedesktop/IBus/Engine/Kime/{}", id);
+        log::info!("CreateEngine({}) -> {}", engine_name, path);
+
+        let engine = IBusEngine::new(self.conn.clone(), path.clone(), self.config.clone());
+
+        if let Err(e) = self.conn.object_server().at(path.as_str(), engine).await {
+            return Err(zbus::fdo::Error::Failed(format!(
+                "Failed to register engine object: {e}"
+            )));
+        }
+
+        OwnedObjectPath::try_from(path)
+            .map_err(|e| zbus::fdo::Error::Failed(format!("Invalid object path: {e}")))
+    }
+}

--- a/src/frontends/ibus/src/ibus_types.rs
+++ b/src/frontends/ibus/src/ibus_types.rs
@@ -1,0 +1,74 @@
+//! Construction of the IBus serializable wire types used by the
+//! `org.freedesktop.IBus.Engine` signals.
+//!
+//! Every IBus serializable object is marshalled as a D-Bus struct whose first
+//! two fields are the GType name (`s`) and an attachments dictionary (`a{sv}`),
+//! followed by the type specific fields. We only need two of them and always
+//! produce them empty/attribute-less:
+//!
+//! * `IBusText`     -> `(sa{sv}sv)` = (name, attachments, text, attrs-variant)
+//! * `IBusAttrList` -> `(sa{sv}av)` = (name, attachments, attributes)
+//!
+//! The attribute list is wrapped in a variant (`v`) inside `IBusText`, matching
+//! `ibus_text_serialize()` in upstream IBus. We force that nesting with
+//! `Value::Value(Box::new(..))`, since a plain `Value::Structure` field would be
+//! marshalled inline instead of as a variant.
+
+use std::collections::HashMap;
+use zbus::zvariant::Value;
+
+/// Build an empty `IBusAttrList` (no attributes).
+fn ibus_attr_list() -> Value<'static> {
+    let v: Value = (
+        "IBusAttrList".to_string(),
+        HashMap::<String, Value>::new(), // a{sv} attachments
+        Vec::<Value>::new(),             // av  attributes
+    )
+        .into();
+    v
+}
+
+/// Build an `IBusText` wrapping `text` with an empty attribute list.
+///
+/// The returned [`Value`] is a `Value::Structure` with signature `(sa{sv}sv)`.
+/// When passed as a single signal argument it is marshalled as a variant (`v`),
+/// which is exactly what `CommitText`/`UpdatePreeditText` expect.
+pub fn ibus_text(text: &str) -> Value<'static> {
+    // The `attrs` field must be a variant wrapping the IBusAttrList struct.
+    let attrs = Value::Value(Box::new(ibus_attr_list()));
+    let v: Value = (
+        "IBusText".to_string(),
+        HashMap::<String, Value>::new(), // a{sv} attachments
+        text.to_string(),                // s text
+        attrs,                           // v attrs (IBusAttrList)
+    )
+        .into();
+    v
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zbus::zvariant::{serialized::Context, to_bytes, LE};
+
+    #[test]
+    fn attr_list_signature() {
+        assert_eq!(ibus_attr_list().value_signature().to_string(), "(sa{sv}av)");
+    }
+
+    #[test]
+    fn text_signature() {
+        // IBusText marshals as the documented (sa{sv}sv) struct.
+        assert_eq!(ibus_text("가").value_signature().to_string(), "(sa{sv}sv)");
+    }
+
+    #[test]
+    fn text_round_trips_as_variant() {
+        // Emitting it as a single signal arg must produce a variant (`v`) whose
+        // inner value is the IBusText struct, and that must demarshal back.
+        let ctxt = Context::new_dbus(LE, 0);
+        let encoded = to_bytes(ctxt, &(ibus_text("한글"),)).unwrap();
+        let (decoded, _): ((Value,), _) = encoded.deserialize().unwrap();
+        assert_eq!(decoded.0.value_signature().to_string(), "(sa{sv}sv)");
+    }
+}

--- a/src/frontends/ibus/src/lib.rs
+++ b/src/frontends/ibus/src/lib.rs
@@ -1,0 +1,11 @@
+//! kime-ibus: an IBus engine that forwards key events to the kime input engine.
+//!
+//! This is the path for GNOME Wayland (Mutter lacks `zwp_input_method_v2`), where
+//! IBus is the supported input-method protocol. See issues #422 and #748.
+
+mod connection;
+mod engine;
+mod factory;
+mod ibus_types;
+
+pub use connection::run;

--- a/src/frontends/ibus/src/main.rs
+++ b/src/frontends/ibus/src/main.rs
@@ -1,0 +1,12 @@
+#[tokio::main]
+async fn main() {
+    // Handles --help/--version/--log and sets up logging; returns the parsed args.
+    let mut args = kime_version::cli_boilerplate!((),);
+    // Launched by ibus-daemon as `kime-ibus --ibus`; accept and ignore the flag.
+    let _ = args.contains("--ibus");
+
+    if let Err(e) = kime_ibus::run().await {
+        log::error!("kime-ibus exited with error: {}", e);
+        std::process::exit(1);
+    }
+}


### PR DESCRIPTION
## Summary
Add a new **`kime-ibus`** frontend: an IBus engine that forwards input to the kime engine. This is the path for environments where the Wayland input-method protocols are unavailable — notably **GNOME Wayland**, whose Mutter compositor does not implement `zwp_input_method_v2`, so `kime-wayland` cannot work there.

Addresses #422 (IBus server interface) and #748 (Ubuntu 26.04 / GNOME Wayland).

## What it does
- Registers as IBus engine `kime` (component `org.freedesktop.IBus.Kime`), launched on demand by `ibus-daemon` via `kime-ibus --ibus`.
- One `InputEngine` per input context; `ProcessKeyEvent` → `press_key_code` → emits `CommitText` / `UpdatePreeditText` / `HidePreeditText`, mirroring the xim/wayland contract exactly (modifier/keycode/CONSUMED mapping, commit-then-preedit ordering, `LANGUAGE_CHANGED`/`NOT_READY` handling).
- Pure-Rust D-Bus via **zbus 5** (`tokio`), no glib/libibus C deps.

## Scope (MVP)
Parity with xim/wayland: **preedit + commit + key/focus/reset**. **No hanja/candidate UI** — develop's engine exposes no candidate-enumeration API; an IBus lookup table is a clean follow-up once that API exists.

## Build
New meson `ibus` feature (`auto`). Installs the `kime-ibus` binary and `res/ibus/component/kime.xml` to `share/ibus/component/`.
```
meson setup build -Dibus=enabled && ninja -C build && sudo ninja -C build install
ibus write-cache && ibus restart   # then add “Kime” (Korean) in Settings, or: ibus engine kime
```

## Verification
- `cargo build -p kime-ibus` → clean, 0 warnings.
- `cargo test -p kime-ibus` → 3/3 (IBusText/IBusAttrList `(sa{sv}sv)` signature + variant round-trip — the riskiest marshalling).
- Binary runs (`--help`/`--version`).

## Needs live testing (maintainer)
Headless CI can't exercise a real `ibus-daemon`, so the following want a live GNOME-Wayland/IBus session: end-to-end IBusText demarshal + visible preedit/commit; daemon activation via the component XML; real keycode/modifier behavior under the GNOME IBus path; socket-file address fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FT8zVKCvTRgZiMLPpNw8Hs
