### PR TITLE
fix(hangul): revert #719 pass-key bypass that broke Hangul layouts (#754)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Improve
 
+* fix(hangul): revert [#719] — pass keys (layout symbol/number layers such as the sebeolsik shifted right-half) are committed in Hangul mode again instead of being bypassed to the application. Shortcut-modified keys (Ctrl/Alt/Super) have no layout entry and are already passed through by the caller, so the special-case bypass was unnecessary and regressed every Hangul layout. [#754](https://github.com/Riey/kime/issues/754)
+
 ## 3.2.0
 
 ### Breaking

--- a/src/engine/backends/hangul/src/state.rs
+++ b/src/engine/backends/hangul/src/state.rs
@@ -72,13 +72,18 @@ impl HangulEngine {
 
     pub fn key(&mut self, kv: KeyValue, addons: EnumSet<Addon>, commit_buf: &mut String) -> bool {
         let ret = match kv {
-            KeyValue::Pass(_) => {
-                // Commit any pending composition, then leave the key unhandled
-                // (return false) so the original key event reaches the
-                // application. This lets shortcuts bound to special characters
-                // such as '@' or '#' fire even while in Hangul mode (issue #719).
+            KeyValue::Pass(pass) => {
+                // A pass key is a literal character defined by the layout (e.g.
+                // the sebeolsik number/symbol layer). Commit any pending
+                // composition, then emit the literal (issue #754).
+                //
+                // Keys carrying a shortcut modifier (Ctrl/Alt/Super) never reach
+                // here: the layout only has plain/Shift entries, so the lookup
+                // misses and the caller passes the key through to the
+                // application — which is where shortcut handling belongs.
                 self.clear_preedit(commit_buf);
-                return false;
+                commit_buf.push(pass);
+                return true;
             }
             KeyValue::Choseong { cho } => self.state.cho(cho, addons),
             KeyValue::Jungseong { jung, compose } => self.state.jung(jung, compose, addons),
@@ -537,10 +542,9 @@ mod tests {
         );
     }
 
-    // issue #719: pass keys (numbers, symbols, ...) must not be consumed so that
-    // application shortcuts bound to keys like '@' or '#' fire in Hangul mode.
+    // issue #754: a pass key (layout literal) commits its character in Hangul mode.
     #[test]
-    fn pass_key_not_consumed() {
+    fn pass_key() {
         let mut engine = HangulEngine::new(false, PreeditJohabLevel::Needed);
         let mut commit = String::new();
 
@@ -554,15 +558,10 @@ mod tests {
         ));
         assert!(engine.has_preedit());
 
-        // a pass key commits the pending preedit but is NOT consumed
-        assert!(!engine.key(KeyValue::Pass('@'), EnumSet::empty(), &mut commit));
-        assert_eq!(commit, "ㄱ");
+        // a pass key commits the pending preedit and then its own literal
+        assert!(engine.key(KeyValue::Pass('@'), EnumSet::empty(), &mut commit));
+        assert_eq!(commit, "ㄱ@");
         assert!(!engine.has_preedit());
-
-        // with no pending preedit, a pass key is still not consumed and commits nothing
-        commit.clear();
-        assert!(!engine.key(KeyValue::Pass('@'), EnumSet::empty(), &mut commit));
-        assert_eq!(commit, "");
     }
 
     #[test]

--- a/src/engine/core/tests/dubeolsik.rs
+++ b/src/engine/core/tests/dubeolsik.rs
@@ -146,26 +146,34 @@ fn number() {
         (Key::normal(S), "안", ""),
         (Key::normal(G), "않", ""),
         (Key::normal(E), "ㄷ", "않"),
-        // issue #719: a pass key commits the pending preedit but is not consumed,
-        // so the key event passes through to the application.
-        (Key::normal(One), "", "ㄷPASS"),
+        // a pass key commits the pending preedit, then commits its own literal
+        (Key::normal(One), "", "ㄷ1"),
     ]);
 }
 
 #[test]
 fn exclamation_mark() {
-    // issue #719: '!' commits the pending preedit and passes through (not consumed).
-    test_input(&[(Key::shift(R), "ㄲ", ""), (Key::shift(One), "", "ㄲPASS")]);
+    // '!' commits the pending preedit, then commits itself
+    test_input(&[(Key::shift(R), "ㄲ", ""), (Key::shift(One), "", "ㄲ!")]);
 }
 
-// issue #719: special-character shortcuts (@, #, ...) must fire in Hangul mode,
-// which requires the engine to leave the key unhandled (pass it through).
+// issue #754: plain special-character (pass) keys must be typed in Hangul mode,
+// not bypassed to the application.
 #[test]
-fn special_char_bypass() {
-    // with a pending composition, '@' commits it and passes through (not consumed)
-    test_input(&[(Key::normal(R), "ㄱ", ""), (Key::shift(Two), "", "ㄱPASS")]);
-    // with no pending composition, '@' simply passes through
-    test_input(&[(Key::shift(Two), "", "PASS")]);
+fn special_char_commit() {
+    // with a pending composition, '@' commits it and then commits '@'
+    test_input(&[(Key::normal(R), "ㄱ", ""), (Key::shift(Two), "", "ㄱ@")]);
+    // with no pending composition, '@' is committed
+    test_input(&[(Key::shift(Two), "", "@")]);
+}
+
+// issue #754/#719: a shortcut-modified key (Ctrl+...) has no layout entry, so it
+// is bypassed to the application by the caller — shortcut handling lives there,
+// not in the pass-key path.
+#[test]
+fn ctrl_shortcut_bypass() {
+    use kime_engine_core::ModifierState;
+    test_input(&[(Key::new(Two, ModifierState::CONTROL), "", "PASS")]);
 }
 
 #[test]

--- a/src/engine/core/tests/sebeolsik_3_90.rs
+++ b/src/engine/core/tests/sebeolsik_3_90.rs
@@ -98,23 +98,37 @@ fn flexible_compose_order_jong_jung() {
     );
 }
 
-// issue #719: symbol pass keys are not consumed so the key event reaches the app.
 #[test]
 fn s_number() {
     test_input(&[
-        (Key::shift(Two), "", "PASS"),
-        (Key::shift(Three), "", "PASS"),
-        (Key::shift(Four), "", "PASS"),
-        (Key::shift(Five), "", "PASS"),
-        (Key::shift(Six), "", "PASS"),
-        (Key::shift(Seven), "", "PASS"),
-        (Key::shift(Eight), "", "PASS"),
-        (Key::shift(Nine), "", "PASS"),
-        (Key::shift(Zero), "", "PASS"),
+        (Key::shift(Two), "", "@"),
+        (Key::shift(Three), "", "#"),
+        (Key::shift(Four), "", "$"),
+        (Key::shift(Five), "", "%"),
+        (Key::shift(Six), "", "^"),
+        (Key::shift(Seven), "", "&"),
+        (Key::shift(Eight), "", "*"),
+        (Key::shift(Nine), "", "("),
+        (Key::shift(Zero), "", ")"),
     ])
 }
 
 #[test]
 fn colon() {
-    test_input(&[(Key::shift(SemiColon), "", "PASS")]);
+    test_input(&[(Key::shift(SemiColon), "", ":")]);
+}
+
+// issue #754: sebeolsik-390 puts a number/symbol layer on the shifted right-half
+// keys via pass characters. These must be committed, not bypassed to the app
+// (which would type the raw QWERTY letter instead).
+#[test]
+fn s754_number_layer() {
+    test_input(&[(Key::shift(U), "", "7")]);
+    test_input(&[(Key::shift(I), "", "8")]);
+    test_input(&[(Key::shift(O), "", "9")]);
+    test_input(&[(Key::shift(J), "", "4")]);
+    test_input(&[(Key::shift(K), "", "5")]);
+    test_input(&[(Key::shift(L), "", "6")]);
+    test_input(&[(Key::shift(Y), "", "<")]);
+    test_input(&[(Key::shift(P), "", ">")]);
 }

--- a/src/engine/core/tests/sebeolsik_3_91.rs
+++ b/src/engine/core/tests/sebeolsik_3_91.rs
@@ -46,10 +46,10 @@ fn issue_521() {
     ]);
 }
 
-// issue #719: symbol pass keys are not consumed so the key event reaches the app.
+// issue #754: a pass key (here ':') is committed in Hangul mode, not bypassed.
 #[test]
 fn colon() {
-    test_input(&[(Key::normal(Backslash), "", "PASS")]);
+    test_input(&[(Key::normal(Backslash), "", ":")]);
 }
 
 // https://github.com/Riey/kime/issues/520


### PR DESCRIPTION
## Summary
Revert the #719 change that regressed every Hangul layout (issue #754).

On Sebeolsik 390, `Shift+U` typed `U` instead of `7`, etc. #719 made the Hangul `KeyValue::Pass` arm `return false` (bypass to the app) so app shortcuts on special chars could fire — but `Pass` is how layouts emit **literal characters** (the sebeolsik number/symbol layer, `:` …), so those keys leaked the raw keystroke. A per-layout tester sweep found all 4 sebeolsik layouts user-visibly broken (40–47 keys each); dubeolsik bypassed too but its literals equal US-QWERTY so it was masked.

## Why a plain revert (not a modifier-aware special case)
Shortcut handling already lives in the upper layer: `lookup_kv` is keyed on the full `Key` (code + modifier state), and layouts only contain plain/`Shift` entries. So a `Ctrl/Alt/Super`-modified key **misses the lookup → `None` → the caller passes it through** to the application. The `Pass` arm therefore only ever sees plain/Shift keys, and committing the literal is the correct, pre-#719 behavior. (Thanks @Riey for pointing this out.)

## Changes
- Revert the `Pass` arm to commit the layout literal.
- Revert the #719 test edits that baked in the bypass (`dubeolsik`, `sebeolsik_3_90`, `sebeolsik_3_91`).
- Add regression tests: `sebeolsik_3_90::s754_number_layer` (`Shift+U`→`7`…), `dubeolsik::ctrl_shortcut_bypass` (Ctrl+key bypasses via the upper layer), and the `pass_key` unit test.
- Full `cargo test` green.

## Note
This regression is in the unpublished **draft `v3.2.0`** — recommend merging before publishing (re-cut 3.2.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FT8zVKCvTRgZiMLPpNw8Hs
