### PR TITLE
fix(qt6): pass input context IID define to moc

### DIFF
--- a/src/frontends/qt6/meson.build
+++ b/src/frontends/qt6/meson.build
@@ -17,6 +17,7 @@ if qt6_dep.found()
   qt6_moc = qt6_mod.preprocess(
     moc_headers: ['../qt5/src/plugin.hpp', '../qt5/src/input_context.hpp'],
     dependencies: [qt6_dep, kime_engine_dep],
+    moc_extra_arguments: ['-DKIME_QT_IID="org.qt-project.Qt.QPlatformInputContextFactoryInterface.5.1"'],
   )
 
   shared_library('kimeplatforminputcontextplugin',


### PR DESCRIPTION
## Summary
Qt 6 input context plugin metadata is generated by moc, but the Meson build only passed the Qt 6 IID override to the C++ compiler. Passing the same define to Meson's Qt preprocess step makes the generated plugin metadata advertise `org.qt-project.Qt.QPlatformInputContextFactoryInterface.5.1`, so Qt 6 can load the Kime input context plugin.

## Changes
- Pass `KIME_QT_IID` to Qt 6 moc generation through `moc_extra_arguments`
- Keep the existing compiler-side IID define unchanged
- Restore Qt 6 plugin metadata compatibility with current Qt 6 input context discovery

## Verification
- `meson setup /tmp/kime-pr-qt6-check -Dsystem_engine=true -Dgtk3=disabled -Dgtk4=disabled -Dqt5=disabled -Dqt6=enabled -Dcheck=disabled -Dindicator=disabled -Dcandidate_window=disabled -Dxim=disabled -Dwayland=disabled -Dinstall_headers=false -Dinstall_docs=false`: configured a Qt 6-only build successfully
- `meson compile -C /tmp/kime-pr-qt6-check`: built `libkimeplatforminputcontextplugin.so` successfully
- `qtplugininfo6 /tmp/kime-pr-qt6-check/src/frontends/qt6/libkimeplatforminputcontextplugin.so`: reports IID `org.qt-project.Qt.QPlatformInputContextFactoryInterface.5.1` and key `kime`