### PR TITLE
Release v3.2.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Improve
 
+* fix(qt6): pass the input context IID define to moc so the Qt6 immodule plugin metadata is generated correctly **[@isac322]** [#756](https://github.com/Riey/kime/pull/756)
 * fix(hangul): revert [#719] — pass keys (layout symbol/number layers such as the sebeolsik shifted right-half) are committed in Hangul mode again instead of being bypassed to the application. Shortcut-modified keys (Ctrl/Alt/Super) have no layout entry and are already passed through by the caller, so the special-case bypass was unnecessary and regressed every Hangul layout. [#754](https://github.com/Riey/kime/issues/754)
 * Replace cmake build system with meson
   - cargo builds via `custom_target()`, GTK/Qt frontends as `shared_library()`

--- a/src/frontends/qt6/meson.build
+++ b/src/frontends/qt6/meson.build
@@ -17,6 +17,7 @@ if qt6_dep.found()
   qt6_moc = qt6_mod.preprocess(
     moc_headers: ['../qt5/src/plugin.hpp', '../qt5/src/input_context.hpp'],
     dependencies: [qt6_dep, kime_engine_dep],
+    moc_extra_arguments: ['-DKIME_QT_IID="org.qt-project.Qt.QPlatformInputContextFactoryInterface.5.1"'],
   )
 
   shared_library('kimeplatforminputcontextplugin',


### PR DESCRIPTION
Advance `master` to the re-cut v3.2.0 release commit (tag `v3.2.0` = `2539caf`).

The v3.2.0 tag was re-cut to additionally include the #756 qt6 moc IID fix (plus its changelog entry), since the previous draft release was never published. Replaces the already-merged #758 flow; master will be fast-forwarded to the tag commit once release CD is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011zZEPwGxfTneQ88G7V3w9i