### PR TITLE
fix(engine): strip a modifier key's own modifier bit before hotkey matching

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Improve
 
-* fix(engine): strip a modifier key's own modifier bit before hotkey matching, so plain `AltR`/`ControlR` hotkeys fire in Wayland-native apps (hangul toggle in Konsole and other Qt apps on KDE Plasma); supersedes the `M-AltR` default-hotkey workaround from [#719] and removes it from the default config [#725](https://github.com/Riey/kime/issues/725) [#760](https://github.com/Riey/kime/pull/760)
+* fix(engine): hotkey lookup falls back to the key without its own modifier bit — Wayland delivers a modifier key's press with its own modifier already set (X11 reports the pre-event state), so plain `AltR`/`ControlR` hotkeys never fired in Wayland-native apps (hangul toggle in Konsole and other Qt apps on KDE Plasma). Exact bindings such as `M-AltR` keep priority over the fallback [#725](https://github.com/Riey/kime/issues/725) [#760](https://github.com/Riey/kime/pull/760)
 
 ## 3.2.0
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Improve
 
-* fix(engine): hotkey lookup falls back to the key without its own modifier bit — Wayland delivers a modifier key's press with its own modifier already set (X11 reports the pre-event state), so plain `AltR`/`ControlR` hotkeys never fired in Wayland-native apps (hangul toggle in Konsole and other Qt apps on KDE Plasma). Exact bindings such as `M-AltR` keep priority over the fallback [#725](https://github.com/Riey/kime/issues/725) [#760](https://github.com/Riey/kime/pull/760)
+* fix(engine): hotkey lookup falls back to the key without its own modifier bit — Wayland delivers a modifier key's press with its own modifier already set (X11 reports the pre-event state), so plain `AltR`/`ControlR` hotkeys never fired in Wayland-native apps (hangul toggle in Konsole and other Qt apps on KDE Plasma). Exact bindings such as `M-AltR` keep priority over the fallback; the redundant `M-AltR` default hotkey from [#719] is removed [#725](https://github.com/Riey/kime/issues/725) [#760](https://github.com/Riey/kime/pull/760)
 
 ## 3.2.0
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Improve
 
-* fix(engine): hotkey lookup falls back to the key without its own modifier bit — Wayland delivers a modifier key's press with its own modifier already set (X11 reports the pre-event state), so plain `AltR`/`ControlR` hotkeys never fired in Wayland-native apps (hangul toggle in Konsole and other Qt apps on KDE Plasma). Exact bindings such as `M-AltR` keep priority over the fallback; the redundant `M-AltR` default hotkey from [#719] is removed [#725](https://github.com/Riey/kime/issues/725) [#760](https://github.com/Riey/kime/pull/760)
+* fix(engine): hotkey lookup falls back to the key without its own modifier bit — Wayland delivers a modifier key's press with its own modifier already set (X11 reports the pre-event state), so plain `AltR`/`ControlR` hotkeys never fired in Wayland-native apps (hangul toggle in Konsole and other Qt apps on KDE Plasma). Exact bindings such as `M-AltR` keep priority over the fallback; the redundant `M-AltR` default hotkey from [#719] is removed [#760](https://github.com/Riey/kime/pull/760)
 
 ## 3.2.0
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Improve
 
+* fix(engine): strip a modifier key's own modifier bit before hotkey matching, so plain `AltR`/`ControlR` hotkeys fire in Wayland-native apps (hangul toggle in Konsole and other Qt apps on KDE Plasma); supersedes the `M-AltR` default-hotkey workaround from [#719] and removes it from the default config [#725](https://github.com/Riey/kime/issues/725) [#760](https://github.com/Riey/kime/pull/760)
+
 ## 3.2.0
 
 ### Breaking

--- a/res/default_config.yaml
+++ b/res/default_config.yaml
@@ -36,11 +36,6 @@ engine:
       - Hangul
       - Latin
       result: Consume
-    M-AltR:
-      behavior: !Toggle
-      - Hangul
-      - Latin
-      result: Consume
     Hangul:
       behavior: !Toggle
       - Hangul

--- a/res/default_config.yaml
+++ b/res/default_config.yaml
@@ -36,6 +36,11 @@ engine:
       - Hangul
       - Latin
       result: Consume
+    M-AltR:
+      behavior: !Toggle
+      - Hangul
+      - Latin
+      result: Consume
     Hangul:
       behavior: !Toggle
       - Hangul

--- a/src/engine/backend/src/keycode.rs
+++ b/src/engine/backend/src/keycode.rs
@@ -259,6 +259,17 @@ impl KeyCode {
             _ => None,
         }
     }
+
+    /// The modifier bit this key sets while held, if it is a modifier key.
+    pub const fn self_modifier(self) -> Option<ModifierState> {
+        match self {
+            Self::Shift => Some(ModifierState::SHIFT),
+            Self::ControlL | Self::ControlR => Some(ModifierState::CONTROL),
+            Self::AltL | Self::AltR => Some(ModifierState::ALT),
+            Self::SuperL | Self::SuperR => Some(ModifierState::SUPER),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/src/engine/config/src/lib.rs
+++ b/src/engine/config/src/lib.rs
@@ -161,6 +161,8 @@ impl Default for EngineConfig {
             global_hotkeys: btreemap! {
                 Key::normal(KeyCode::Esc) => Hotkey::new(HotkeyBehavior::Switch(InputCategory::Latin), HotkeyResult::Bypass),
                 Key::normal(KeyCode::AltR) => Hotkey::new(HotkeyBehavior::toggle_hangul_latin(), HotkeyResult::Consume),
+                // Sometimes Alt_R contains Alt modifier state
+                Key::alt(KeyCode::AltR) => Hotkey::new(HotkeyBehavior::toggle_hangul_latin(), HotkeyResult::Consume),
                 Key::normal(KeyCode::Hangul) => Hotkey::new(HotkeyBehavior::toggle_hangul_latin(), HotkeyResult::Consume),
                 Key::super_(KeyCode::Space) => Hotkey::new(HotkeyBehavior::toggle_hangul_latin(), HotkeyResult::Consume),
                 Key::normal(KeyCode::Muhenkan) => Hotkey::new(HotkeyBehavior::toggle_hangul_latin(), HotkeyResult::Consume),

--- a/src/engine/config/src/lib.rs
+++ b/src/engine/config/src/lib.rs
@@ -161,8 +161,6 @@ impl Default for EngineConfig {
             global_hotkeys: btreemap! {
                 Key::normal(KeyCode::Esc) => Hotkey::new(HotkeyBehavior::Switch(InputCategory::Latin), HotkeyResult::Bypass),
                 Key::normal(KeyCode::AltR) => Hotkey::new(HotkeyBehavior::toggle_hangul_latin(), HotkeyResult::Consume),
-                // Sometimes Alt_R contains Alt modifier state
-                Key::alt(KeyCode::AltR) => Hotkey::new(HotkeyBehavior::toggle_hangul_latin(), HotkeyResult::Consume),
                 Key::normal(KeyCode::Hangul) => Hotkey::new(HotkeyBehavior::toggle_hangul_latin(), HotkeyResult::Consume),
                 Key::super_(KeyCode::Space) => Hotkey::new(HotkeyBehavior::toggle_hangul_latin(), HotkeyResult::Consume),
                 Key::normal(KeyCode::Muhenkan) => Hotkey::new(HotkeyBehavior::toggle_hangul_latin(), HotkeyResult::Consume),

--- a/src/engine/core/src/lib.rs
+++ b/src/engine/core/src/lib.rs
@@ -94,7 +94,7 @@ impl InputEngine {
     /// reachable, then retry without the key's own modifier bit: Wayland
     /// delivers a modifier key's press with its own bit already set, unlike
     /// X11 which reports the pre-event state, so a plain `AltR` binding
-    /// would otherwise never match there (#725).
+    /// would otherwise never match there.
     fn try_hotkey_self_modifier(&self, key: Key, config: &Config) -> Option<Hotkey> {
         self.try_hotkey(key, config).or_else(|| {
             let modifier = key.code.self_modifier()?;

--- a/src/engine/core/src/lib.rs
+++ b/src/engine/core/src/lib.rs
@@ -90,7 +90,15 @@ impl InputEngine {
         }
     }
 
-    pub fn press_key(&mut self, key: Key, config: &Config) -> InputResult {
+    pub fn press_key(&mut self, mut key: Key, config: &Config) -> InputResult {
+        // Wayland delivers a modifier key's press with its own modifier bit
+        // already set, unlike X11 which reports the pre-event state; drop the
+        // key's own bit so exact hotkey matches like `AltR` behave the same
+        // on both (#725).
+        if let Some(modifier) = key.code.self_modifier() {
+            key.state.remove(modifier);
+        }
+
         self.try_get_global_input_category_state(config);
 
         let mut ret = InputResult::empty();

--- a/src/engine/core/src/lib.rs
+++ b/src/engine/core/src/lib.rs
@@ -90,20 +90,28 @@ impl InputEngine {
         }
     }
 
-    pub fn press_key(&mut self, mut key: Key, config: &Config) -> InputResult {
-        // Wayland delivers a modifier key's press with its own modifier bit
-        // already set, unlike X11 which reports the pre-event state; drop the
-        // key's own bit so exact hotkey matches like `AltR` behave the same
-        // on both (#725).
-        if let Some(modifier) = key.code.self_modifier() {
-            key.state.remove(modifier);
-        }
+    /// Look up `key` as-is first so explicit bindings like `M-AltR` stay
+    /// reachable, then retry without the key's own modifier bit: Wayland
+    /// delivers a modifier key's press with its own bit already set, unlike
+    /// X11 which reports the pre-event state, so a plain `AltR` binding
+    /// would otherwise never match there (#725).
+    fn try_hotkey_self_modifier(&self, key: Key, config: &Config) -> Option<Hotkey> {
+        self.try_hotkey(key, config).or_else(|| {
+            let modifier = key.code.self_modifier()?;
+            if key.state.contains(modifier) {
+                self.try_hotkey(Key::new(key.code, key.state.difference(modifier)), config)
+            } else {
+                None
+            }
+        })
+    }
 
+    pub fn press_key(&mut self, key: Key, config: &Config) -> InputResult {
         self.try_get_global_input_category_state(config);
 
         let mut ret = InputResult::empty();
 
-        if let Some(hotkey) = self.try_hotkey(key, config) {
+        if let Some(hotkey) = self.try_hotkey_self_modifier(key, config) {
             let mut processed = false;
             match hotkey.behavior() {
                 HotkeyBehavior::Switch(category) => {

--- a/src/engine/core/tests/self_modifier.rs
+++ b/src/engine/core/tests/self_modifier.rs
@@ -1,0 +1,83 @@
+use kime_engine_config::{HotkeyBehavior, HotkeyResult};
+use kime_engine_core::{
+    Config, EngineConfig, Hotkey, InputCategory, InputEngine, InputResult, Key, KeyCode,
+    ModifierState,
+};
+use pretty_assertions::assert_eq;
+
+// X11 hardware keycodes (evdev + 8).
+const ALT_R: u16 = 108;
+const CONTROL_R: u16 = 105;
+const KEY_E: u16 = 26;
+
+fn toggle_config(hotkey: Key) -> Config {
+    let mut engine_config = EngineConfig::default();
+    engine_config.global_hotkeys = std::iter::once((
+        hotkey,
+        Hotkey::new(HotkeyBehavior::toggle_hangul_latin(), HotkeyResult::Consume),
+    ))
+    .collect();
+    // The default category hotkeys bind ControlR to Hanja mode, which would
+    // shadow the global toggle under test.
+    engine_config.category_hotkeys.clear();
+    Config::new(engine_config)
+}
+
+/// On Wayland the press of a modifier key is delivered with its own modifier
+/// bit already set (X11 reports the pre-event state), e.g. AltR arrives as
+/// `Key { AltR, ALT }`. A config entry written as plain `AltR` must still
+/// match. Issue #725.
+#[test]
+fn altr_toggle_matches_when_own_modifier_is_set() {
+    let config = toggle_config(Key::normal(KeyCode::AltR));
+    let mut engine = InputEngine::new(&config);
+    engine.set_input_category(InputCategory::Hangul);
+
+    let ret = engine.press_key_code(ALT_R, ModifierState::ALT, false, &config);
+    assert!(ret.contains(InputResult::CONSUMED));
+    assert_eq!(engine.category(), InputCategory::Latin);
+}
+
+/// Same as the AltR case for the right control key, which is commonly bound
+/// as the Hanja hotkey.
+#[test]
+fn control_r_hotkey_matches_when_own_modifier_is_set() {
+    let config = toggle_config(Key::normal(KeyCode::ControlR));
+    let mut engine = InputEngine::new(&config);
+    engine.set_input_category(InputCategory::Hangul);
+
+    let ret = engine.press_key_code(CONTROL_R, ModifierState::CONTROL, false, &config);
+    assert!(ret.contains(InputResult::CONSUMED));
+    assert_eq!(engine.category(), InputCategory::Latin);
+}
+
+/// Only the key's own modifier bit may be dropped: `C-AltR` pressed while
+/// control is held arrives as CONTROL|ALT and must still match.
+#[test]
+fn combo_hotkey_on_modifier_key_still_matches() {
+    let config = toggle_config(Key::ctrl(KeyCode::AltR));
+    let mut engine = InputEngine::new(&config);
+    engine.set_input_category(InputCategory::Hangul);
+
+    let ret = engine.press_key_code(
+        ALT_R,
+        ModifierState::CONTROL | ModifierState::ALT,
+        false,
+        &config,
+    );
+    assert!(ret.contains(InputResult::CONSUMED));
+    assert_eq!(engine.category(), InputCategory::Latin);
+}
+
+/// Non-modifier keys must keep their full state: `M-E` style hotkeys rely on
+/// the ALT bit staying put when E is pressed.
+#[test]
+fn non_modifier_key_state_is_untouched() {
+    let config = toggle_config(Key::alt(KeyCode::E));
+    let mut engine = InputEngine::new(&config);
+    engine.set_input_category(InputCategory::Hangul);
+
+    let ret = engine.press_key_code(KEY_E, ModifierState::ALT, false, &config);
+    assert!(ret.contains(InputResult::CONSUMED));
+    assert_eq!(engine.category(), InputCategory::Latin);
+}

--- a/src/engine/core/tests/self_modifier.rs
+++ b/src/engine/core/tests/self_modifier.rs
@@ -69,6 +69,52 @@ fn combo_hotkey_on_modifier_key_still_matches() {
     assert_eq!(engine.category(), InputCategory::Latin);
 }
 
+/// A config that binds only `M-AltR` (the pre-existing Wayland workaround)
+/// must keep working: the exact modified key is looked up before the
+/// self-modifier fallback.
+#[test]
+fn explicit_same_class_binding_stays_reachable() {
+    let config = toggle_config(Key::alt(KeyCode::AltR));
+    let mut engine = InputEngine::new(&config);
+    engine.set_input_category(InputCategory::Hangul);
+
+    let ret = engine.press_key_code(ALT_R, ModifierState::ALT, false, &config);
+    assert!(ret.contains(InputResult::CONSUMED));
+    assert_eq!(engine.category(), InputCategory::Latin);
+}
+
+/// When both `AltR` and `M-AltR` are bound, the exact match must win over
+/// the self-modifier fallback.
+#[test]
+fn exact_match_beats_self_modifier_fallback() {
+    let mut engine_config = EngineConfig::default();
+    engine_config.global_hotkeys = [
+        (
+            Key::normal(KeyCode::AltR),
+            Hotkey::new(
+                HotkeyBehavior::Switch(InputCategory::Hangul),
+                HotkeyResult::Consume,
+            ),
+        ),
+        (
+            Key::alt(KeyCode::AltR),
+            Hotkey::new(
+                HotkeyBehavior::Switch(InputCategory::Latin),
+                HotkeyResult::Consume,
+            ),
+        ),
+    ]
+    .into_iter()
+    .collect();
+    engine_config.category_hotkeys.clear();
+    let config = Config::new(engine_config);
+    let mut engine = InputEngine::new(&config);
+    engine.set_input_category(InputCategory::Hangul);
+
+    engine.press_key_code(ALT_R, ModifierState::ALT, false, &config);
+    assert_eq!(engine.category(), InputCategory::Latin);
+}
+
 /// Non-modifier keys must keep their full state: `M-E` style hotkeys rely on
 /// the ALT bit staying put when E is pressed.
 #[test]

--- a/src/engine/core/tests/self_modifier.rs
+++ b/src/engine/core/tests/self_modifier.rs
@@ -26,7 +26,7 @@ fn toggle_config(hotkey: Key) -> Config {
 /// On Wayland the press of a modifier key is delivered with its own modifier
 /// bit already set (X11 reports the pre-event state), e.g. AltR arrives as
 /// `Key { AltR, ALT }`. A config entry written as plain `AltR` must still
-/// match. Issue #725.
+/// match.
 #[test]
 fn altr_toggle_matches_when_own_modifier_is_set() {
     let config = toggle_config(Key::normal(KeyCode::AltR));


### PR DESCRIPTION
## Problem

On Wayland, a modifier key's press is delivered with its own modifier bit already active — KWin+Qt was measured delivering right-Alt as `Key { AltR, ALT }` — while X11 reports the pre-event state (`Key { AltR, ∅ }`). kime's hotkey lookup is an exact match, so plain `AltR` / `ControlR` hotkeys never fired in Wayland-native apps: hangul toggle was broken in Qt apps such as Konsole on KDE Plasma, while the same config worked under XWayland.

## Fix

Normalize at the engine boundary: hotkey lookup tries the incoming key exactly first (so explicit bindings such as `M-AltR` stay reachable and take priority), then retries with the pressed key's own modifier bit removed (`KeyCode::self_modifier`). This covers the qt5/qt6/gtk3/gtk4/xim/wayland frontends at once; on X11 the bit is never set, so the fallback is a no-op there. Combo hotkeys such as `C-AltR` keep their other modifiers.

The `M-AltR` default hotkey added by #719 is identical to the plain `AltR` toggle under the fallback, so it is removed from the default config. User configs that bind `M-AltR` to something else keep working via exact-match priority.

## Verification

- New `self_modifier` tests reproduce the captured Wayland event and cover ControlR, `C-AltR` combos, exact-vs-fallback precedence, `M-AltR`-only configs, and non-modifier keys (state untouched); written first and observed failing.
- Full workspace test suite passes; `cargo fmt --check` clean; no new clippy warnings.
- Headless C API before/after comparison with a real user config: the installed engine ignores `press_key(108, ALT)` (`ret=0x00`), the patched engine toggles (`CONSUMED|LANGUAGE_CHANGED`) and the follow-up key sequence behaves correctly in both categories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XznmnFSRcLncfbQoiVoPqU