### PR TITLE
ci: run workflows on self-hosted runners

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,14 +26,17 @@ jobs:
           init: none
           extra-conf: |
             substituters = http://172.30.0.251:8080 https://cache.nixos.org
-      - name: Caching cargo
+      - name: Caching cargo and nix inputs
         uses: actions/cache@v4
         with:
+          # ~/.cache/nix holds fetched flake inputs (the nixpkgs tarball
+          # alone costs ~10s per run on the ephemeral runners)
           path: |
             ~/.cargo/registry
             ~/.cargo/git
+            ~/.cache/nix
             target
-          key: ${{ runner.os }}-nix-rustc-v1-1.55.0-${{ hashFiles('Cargo.lock') }}
+          key: ${{ runner.os }}-nix-rustc-v1-1.55.0-${{ hashFiles('Cargo.lock', 'flake.lock') }}
           restore-keys: |
             ${{ runner.os }}-nix-rustc-v1-1.55.0-
       - run: nix develop -c meson setup build --buildtype=debug -Dcargo_profile=debug

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,10 +18,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      # init: none — the runner is an ephemeral container without systemd
+      # init: none — the runner is an ephemeral container without systemd.
+      # The first substituter is a local caching proxy for cache.nixos.org;
+      # nix falls back to the real cache if it is unreachable.
       - uses: DeterminateSystems/nix-installer-action@v22
         with:
           init: none
+          extra-conf: |
+            substituters = http://172.30.0.251:8080 https://cache.nixos.org
       - name: Caching cargo
         uses: actions/cache@v4
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,13 +14,14 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    runs-on: [self-hosted, docker-ci]
 
     steps:
       - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v18
+      # init: none — the runner is an ephemeral container without systemd
+      - uses: DeterminateSystems/nix-installer-action@v22
         with:
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+          init: none
       - name: Caching cargo
         uses: actions/cache@v4
         with:
@@ -36,28 +37,37 @@ jobs:
       - run: nix develop -c cargo test
 
   cargo-deny:
-    runs-on: ubuntu-24.04
+    runs-on: [self-hosted, docker-ci]
     strategy:
       matrix:
         checks:
           - bans licenses sources
 
+    # cargo-deny-action is a Docker action, which the self-hosted runner
+    # (a container without a docker socket) can't run — install the binary
+    # instead. cargo-deny shells out to `cargo metadata`, hence the toolchain.
     steps:
       - uses: actions/checkout@v4
-      - uses: EmbarkStudios/cargo-deny-action@v2
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-deny
+      - run: cargo deny check ${{ matrix.checks }}
 
   format:
-    runs-on: ubuntu-24.04
+    runs-on: [self-hosted, docker-ci]
 
     steps:
       - uses: actions/checkout@v4
-      - name: Install Rustfmt
-        run: rustup component add rustfmt
+      # the runner image has no rustup; this installs it with rustfmt included
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
       - name: Check Rustfmt
         run: cargo fmt -- --check
 
   spell-check:
-    runs-on: ubuntu-24.04
+    runs-on: [self-hosted, docker-ci]
     steps:
       - uses: actions/checkout@v4
       - uses: crate-ci/typos@master

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,12 +10,13 @@ permissions:
 
 jobs:
   build-archive:
-    runs-on: ubuntu-24.04
+    runs-on: [self-hosted, docker-ci]
     steps:
       - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v18
+      # init: none — the runner is an ephemeral container without systemd
+      - uses: DeterminateSystems/nix-installer-action@v22
         with:
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+          init: none
 
       - name: Build
         run: |
@@ -57,12 +58,18 @@ jobs:
 
   build-qt5:
     needs: build-archive
-    runs-on: ubuntu-24.04
+    runs-on: [self-hosted, docker-ci]
     strategy:
       matrix:
         qt5: ['5.12.8', '5.15.2']
     steps:
       - uses: actions/checkout@v4
+
+      # install-qt-action needs pip; the runner container's system python
+      # is externally managed (PEP 668), so bring an isolated one
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
 
       - name: Download engine
         uses: actions/download-artifact@v4
@@ -101,12 +108,18 @@ jobs:
 
   build-qt6:
     needs: build-archive
-    runs-on: ubuntu-24.04
+    runs-on: [self-hosted, docker-ci]
     strategy:
       matrix:
         qt6: ['6.2.4', '6.5.3', '6.7.3', '6.8.2', '6.9.3', '6.10.3']
     steps:
       - uses: actions/checkout@v4
+
+      # install-qt-action needs pip; the runner container's system python
+      # is externally managed (PEP 668), so bring an isolated one
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
 
       - name: Download engine
         uses: actions/download-artifact@v4
@@ -144,7 +157,9 @@ jobs:
           files: libkime-qt-${{ matrix.qt6 }}.so
 
   build-deb:
-    runs-on: ubuntu-24.04
+    # needs a docker daemon for `container:` jobs, so this runs on the host
+    # runner, not the sandboxed docker-ci one (tag pushes only — trusted code)
+    runs-on: [self-hosted, arch]
     container: ${{ matrix.container }}
     strategy:
       matrix:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,10 +13,14 @@ jobs:
     runs-on: [self-hosted, docker-ci]
     steps:
       - uses: actions/checkout@v4
-      # init: none — the runner is an ephemeral container without systemd
+      # init: none — the runner is an ephemeral container without systemd.
+      # The first substituter is a local caching proxy for cache.nixos.org;
+      # nix falls back to the real cache if it is unreachable.
       - uses: DeterminateSystems/nix-installer-action@v22
         with:
           init: none
+          extra-conf: |
+            substituters = http://172.30.0.251:8080 https://cache.nixos.org
 
       - name: Build
         run: |


### PR DESCRIPTION
Route CI to the sandboxed ephemeral container runners (`docker-ci`) and the release `build-deb` job to the host runner (`arch`), which has the docker daemon that `container:` jobs require. Tag pushes only run trusted code, so the host runner is safe there; PR code always lands in a socket-less, single-use container.

Container-runner compatibility changes:

- `cachix/install-nix-action` → `DeterminateSystems/nix-installer-action` with `init: none` (the runner container has no systemd)
- `cargo-deny-action` is a Docker action the runner can't execute — install `cargo-deny` via `taiki-e/install-action` instead, plus a rust toolchain for `cargo metadata`
- format job installs rustup via `dtolnay/rust-toolchain` (the runner image ships none)
- qt jobs get `actions/setup-python` so `install-qt-action`'s pip usage survives PEP 668

Draft until the first CI run on the new runners comes back green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiTdUodigqtcjCQbmS1QNH