### PR TITLE
Update toolchains to latest

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: [self-hosted, docker-ci]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       # init: none — the runner is an ephemeral container without systemd.
       # The first substituter is a local caching proxy for cache.nixos.org;
       # nix falls back to the real cache if it is unreachable.
@@ -27,7 +27,7 @@ jobs:
           extra-conf: |
             substituters = http://172.30.0.251:8080 https://cache.nixos.org
       - name: Caching cargo and nix inputs
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           # ~/.cache/nix holds fetched flake inputs (the nixpkgs tarball
           # alone costs ~10s per run on the ephemeral runners)
@@ -36,9 +36,9 @@ jobs:
             ~/.cargo/git
             ~/.cache/nix
             target
-          key: ${{ runner.os }}-nix-rustc-v1-1.55.0-${{ hashFiles('Cargo.lock', 'flake.lock') }}
+          key: ${{ runner.os }}-nix-rustc-v1-1.97.1-${{ hashFiles('Cargo.lock', 'flake.lock') }}
           restore-keys: |
-            ${{ runner.os }}-nix-rustc-v1-1.55.0-
+            ${{ runner.os }}-nix-rustc-v1-1.97.1-
       - run: nix develop -c meson setup build --buildtype=debug -Dcargo_profile=debug
       - run: nix develop -c ninja -C build
       - run: nix develop -c cargo test
@@ -54,7 +54,7 @@ jobs:
     # (a container without a docker socket) can't run — install the binary
     # instead. cargo-deny shells out to `cargo metadata`, hence the toolchain.
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@v2
         with:
@@ -65,7 +65,7 @@ jobs:
     runs-on: [self-hosted, docker-ci]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       # the runner image has no rustup; this installs it with rustfmt included
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -76,5 +76,5 @@ jobs:
   spell-check:
     runs-on: [self-hosted, docker-ci]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: crate-ci/typos@master

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ jobs:
   build-archive:
     runs-on: [self-hosted, docker-ci]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       # init: none — the runner is an ephemeral container without systemd.
       # The first substituter is a local caching proxy for cache.nixos.org;
       # nix falls back to the real cache if it is unreachable.
@@ -39,7 +39,7 @@ jobs:
           done
 
       - name: Upload engine artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: engine
           path: |
@@ -55,7 +55,7 @@ jobs:
           tar -C kime-install -caf kime-${{ github.ref_name }}.tar.zst .
 
       - name: Upload release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           draft: true
           files: kime-${{ github.ref_name }}.tar.zst
@@ -67,16 +67,16 @@ jobs:
       matrix:
         qt5: ['5.12.8', '5.15.2']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       # install-qt-action needs pip; the runner container's system python
       # is externally managed (PEP 668), so bring an isolated one
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
-          python-version: '3.12'
+          python-version: '3.13'
 
       - name: Download engine
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: engine
           path: ./engine-artifacts
@@ -105,7 +105,7 @@ jobs:
           cp build/src/frontends/qt5/libkimeplatforminputcontextplugin.so libkime-qt-${{ matrix.qt5 }}.so
 
       - name: Upload release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           draft: true
           files: libkime-qt-${{ matrix.qt5 }}.so
@@ -117,16 +117,16 @@ jobs:
       matrix:
         qt6: ['6.2.4', '6.5.3', '6.7.3', '6.8.2', '6.9.3', '6.10.3']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       # install-qt-action needs pip; the runner container's system python
       # is externally managed (PEP 668), so bring an isolated one
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
-          python-version: '3.12'
+          python-version: '3.13'
 
       - name: Download engine
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: engine
           path: ./engine-artifacts
@@ -155,7 +155,7 @@ jobs:
           cp build/src/frontends/qt6/libkimeplatforminputcontextplugin.so libkime-qt-${{ matrix.qt6 }}.so
 
       - name: Upload release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           draft: true
           files: libkime-qt-${{ matrix.qt6 }}.so
@@ -220,7 +220,7 @@ jobs:
           export PATH="$HOME/.cargo/bin:$PATH"
           rustup default stable
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Build
         run: |
@@ -248,7 +248,7 @@ jobs:
           mv output/kime_*_${ARCH}.deb "output/kime-${{ github.ref_name }}_${ARCH}_${{ matrix.suffix }}.deb"
 
       - name: Upload release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           draft: true
           files: output/kime-*.deb

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1769049916,
-        "narHash": "sha256-RcsY0BtjUhRuA1SRcqMrVpWC8cQkfCzhVcYdiBzDxNw=",
+        "lastModified": 1785171194,
+        "narHash": "sha256-+e7/rKMfTbD629CnMhWNraYvU81gC7mZhkGm0J1KvbU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "47f3deb4bc905ce0de12ba7bd6ad002c132acd02",
+        "rev": "8507ef13c07fc501e802cd01409a63c7372b095c",
         "type": "github"
       },
       "original": {
@@ -61,11 +61,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1769050281,
-        "narHash": "sha256-1H8DN4UZgEUqPUA5ecHOufLZMscJ4IlcGaEftaPtpBY=",
+        "lastModified": 1785131767,
+        "narHash": "sha256-VNbQv2P0zgaNh96mT4LrnX7hdXgiC5nBH+uvyrrVX7U=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "6deef0585c52d9e70f96b6121207e1496d4b0c49",
+        "rev": "c67ce00525464a710971351c183ce67acb6ca827",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
- `nix flake update`: nixpkgs and rust-overlay move from 2026-01-22 to 2026-07-27 snapshots — the devshell now provides **rustc 1.97.1** (was pinned to a January snapshot; the cargo cache key even carried a `1.55.0` label from 2021, now stamped `1.97.1`). Eval-verified with `nix flake check`.
- CI actions bumped to latest majors: checkout v7, cache v6, upload-artifact v7, download-artifact v8, action-gh-release v3, setup-python v7 (python 3.13). `dtolnay/rust-toolchain@stable`, `taiki-e/install-action@v2`, `nix-installer-action@v22`, and `install-qt-action@v4` are already current.

Notes:
- The new flake.lock + key label mean the first CI run rebuilds the cargo cache cold; runs after that are warm again.
- The release.yaml action bumps (artifact up/download, gh-release, setup-python) only get exercised on the next tag push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiTdUodigqtcjCQbmS1QNH