### PR TITLE
perf: link with mold

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,9 +36,9 @@ jobs:
             ~/.cargo/git
             ~/.cache/nix
             target
-          key: ${{ runner.os }}-nix-rustc-v1-1.97.1-${{ hashFiles('Cargo.lock', 'flake.lock') }}
+          key: ${{ runner.os }}-nix-rustc-v1-1.97.1-mold-${{ hashFiles('Cargo.lock', 'flake.lock') }}
           restore-keys: |
-            ${{ runner.os }}-nix-rustc-v1-1.97.1-
+            ${{ runner.os }}-nix-rustc-v1-1.97.1-mold-
       - run: nix develop -c meson setup build --buildtype=debug -Dcargo_profile=debug
       - run: nix develop -c ninja -C build
       - run: nix develop -c cargo test

--- a/shell.nix
+++ b/shell.nix
@@ -17,9 +17,14 @@ mkShell {
   buildInputs = deps.kimeBuildInputs;
   nativeBuildInputs = deps.kimeNativeBuildInputs ++ [
     rustToolchain
+    pkgs.mold
     pkgs.gedit
     pkgs.llvmPackages_18.lldb
   ];
+  # link with mold (rust via the clang driver, meson C/C++ via CC_LD/CXX_LD)
+  RUSTFLAGS = "-C link-arg=-fuse-ld=mold";
+  CC_LD = "mold";
+  CXX_LD = "mold";
   LIBCLANG_PATH = "${pkgs.llvmPackages_18.libclang.lib}/lib";
   LD_LIBRARY_PATH = "./target/debug:${pkgs.wayland}/lib:${pkgs.libGL}/lib:${pkgs.libxkbcommon}/lib";
   G_MESSAGES_DEBUG = "kime";


### PR DESCRIPTION
Speed experiment: route rust and meson C/C++ linking through mold in the devshell. Draft until warm-cache CI timings show whether it pays for itself against the ld.lld/bfd baseline (~55s warm build job).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiTdUodigqtcjCQbmS1QNH