### PR TITLE
ci: use runner-image toolchains, cancel superseded runs, fix cache key

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,12 @@ on:
     branches:
       - "develop"
 
+# A superseded push cancels the older PR run so it stops occupying the
+# 4-slot docker-ci pool; pushes to develop always run to completion.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -18,58 +24,37 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
-      # init: none — the runner is an ephemeral container without systemd.
-      # The first substituter is a local caching proxy for cache.nixos.org;
-      # nix falls back to the real cache if it is unreachable.
-      - uses: DeterminateSystems/nix-installer-action@v22
-        with:
-          init: none
-          extra-conf: |
-            substituters = http://172.30.0.251:8080 https://cache.nixos.org
-      - name: Caching cargo and nix inputs
+      # nix and the kime devshell closure are baked into the runner image
+      # (~/actions-runner-docker/build.sh) — rebuild it on flake.lock bumps.
+      - name: Caching cargo
         uses: actions/cache@v6
         with:
-          # ~/.cache/nix holds fetched flake inputs (the nixpkgs tarball
-          # alone costs ~10s per run on the ephemeral runners)
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            ~/.cache/nix
             target
-          key: ${{ runner.os }}-nix-rustc-v1-1.97.1-${{ hashFiles('Cargo.lock', 'flake.lock') }}
+          # scoped to flake.lock so a toolchain bump never restores an
+          # incompatible target dir (the flake pins rustc)
+          key: ${{ runner.os }}-ci-v2-${{ hashFiles('flake.lock') }}-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-nix-rustc-v1-1.97.1-
+            ${{ runner.os }}-ci-v2-${{ hashFiles('flake.lock') }}-
       - run: nix develop -c meson setup build --buildtype=debug -Dcargo_profile=debug
       - run: nix develop -c ninja -C build
       - run: nix develop -c cargo test
 
+  # cargo-deny-action is a Docker action, which the self-hosted runner (a
+  # container without a docker socket) can't run — the cargo-deny binary and
+  # the toolchain it needs for `cargo metadata` are baked into the image.
   cargo-deny:
     runs-on: [self-hosted, docker-ci]
-    strategy:
-      matrix:
-        checks:
-          - bans licenses sources
-
-    # cargo-deny-action is a Docker action, which the self-hosted runner
-    # (a container without a docker socket) can't run — install the binary
-    # instead. cargo-deny shells out to `cargo metadata`, hence the toolchain.
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-deny
-      - run: cargo deny check ${{ matrix.checks }}
+      - run: cargo deny check bans licenses sources
 
   format:
     runs-on: [self-hosted, docker-ci]
-
     steps:
       - uses: actions/checkout@v7
-      # the runner image has no rustup; this installs it with rustfmt included
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt
       - name: Check Rustfmt
         run: cargo fmt -- --check
 
@@ -77,4 +62,5 @@ jobs:
     runs-on: [self-hosted, docker-ci]
     steps:
       - uses: actions/checkout@v7
-      - uses: crate-ci/typos@master
+      # typos binary baked into the runner image; reads typos.toml
+      - run: typos

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,9 +38,21 @@ jobs:
           key: ${{ runner.os }}-ci-v2-${{ hashFiles('flake.lock') }}-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-ci-v2-${{ hashFiles('flake.lock') }}-
-      - run: nix develop -c meson setup build --buildtype=debug -Dcargo_profile=debug
-      - run: nix develop -c ninja -C build
-      - run: nix develop -c cargo test
+      # Evaluating the repo flake copies the whole tree to the nix store
+      # (~8s/run). When the files that define the devshell match the copies
+      # baked into the image, enter the pre-built profile instead (~1s);
+      # otherwise fall back to the repo flake so a lock bump is never
+      # silently ignored.
+      - name: Pick devshell
+        run: |
+          shell=/opt/kime-devshell
+          for f in flake.nix flake.lock shell.nix nix/deps.nix; do
+            cmp -s "$f" "/opt/kime-flake/$f" || { shell=.; echo "$f differs from the baked image — evaluating the repo flake"; }
+          done
+          echo "DEVSHELL=$shell" >> "$GITHUB_ENV"
+      - run: nix develop "$DEVSHELL" -c meson setup build --buildtype=debug -Dcargo_profile=debug
+      - run: nix develop "$DEVSHELL" -c ninja -C build
+      - run: nix develop "$DEVSHELL" -c cargo test
 
   # cargo-deny-action is a Docker action, which the self-hosted runner (a
   # container without a docker socket) can't run — the cargo-deny binary and


### PR DESCRIPTION
Implements the PR-CI items from the CI performance benchmark (warm build job: 60s, of which ~25-30s was re-materializing toolchains on the ephemeral runners every job).

## Runner image (deployed on rieypc before this PR — CI here runs on it)

`kime-gha-runner:latest` now bakes in:
- nix (Determinate installer, `init: none`) with the LAN proxy as first substituter, plus the **kime devshell closure** GC-rooted via `nix develop --profile` — `nix develop` cold in a fresh container: **1.6s** (was ~20s: 9s nix-installer + 10.5s substituting 534 store paths)
- rustup stable with rustfmt (system-wide; jobs run as root), `cargo-deny` 0.20.2, `typos` v1.48.0
- rebuild via `~/actions-runner-docker/build.sh` on flake.lock bumps; previous image kept as `kime-gha-runner:previous`

## Workflow changes

- **build**: drop `nix-installer-action`; cache key scoped to `flake.lock` instead of a hand-written rustc version (`1.97.1`) so toolchain bumps can't restore an incompatible multi-GB `target` dir; drop `~/.cache/nix` from the cache (flake inputs live in the baked store now)
- **cargo-deny / format**: drop `dtolnay/rust-toolchain` + `taiki-e/install-action` (~6s each); inline the single-entry matrix (check name becomes `cargo-deny` — no required-check references exist)
- **spell-check**: replace unpinned `crate-ci/typos@master` with the baked, pinned binary
- **concurrency**: superseded PR pushes cancel the older run (observed 8 runs of one branch in 33min occupying the 4-slot pool); develop pushes still run to completion

Also applied outside the repo: `gha-cache-server` recreated with `CACHE_CLEANUP_OLDER_THAN_DAYS=7` + `CACHE_MAX_SIZE_BYTES=20GiB` (was growing ~1GB/day unbounded) and its IP pinned to 172.30.0.250.

Expected: build ~60s → ~30-35s warm, format/cargo-deny/spell-check ~17/21/11s → ~10/14/5s. The checks on this PR are the first validation on the new image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XznmnFSRcLncfbQoiVoPqU