### PR TITLE
ci: rebuild the runner image when the devshell definition changes

### DIFF
--- a/.github/workflows/runner-image.yaml
+++ b/.github/workflows/runner-image.yaml
@@ -1,0 +1,34 @@
+name: Runner image
+
+# Rebuild the kime-gha-runner docker image whenever the files that define
+# the CI devshell change on develop, so the closure baked into the image
+# (see ci.yaml) tracks the repo. No runner restart needed: the ephemeral
+# docker-ci runners resolve :latest on every respawn, so each serves at
+# most one more job on the old image — and that job still works because
+# ci.yaml falls back to evaluating the repo flake when the baked copies
+# don't match.
+
+on:
+  push:
+    branches:
+      - "develop"
+    paths:
+      - flake.nix
+      - flake.lock
+      - shell.nix
+      - nix/**
+  workflow_dispatch:
+
+concurrency:
+  group: runner-image
+  cancel-in-progress: false
+
+jobs:
+  rebuild:
+    # the trusted host runner: it has docker access and only ever runs
+    # code already merged to develop (or manually dispatched refs)
+    runs-on: [self-hosted, arch]
+    steps:
+      - uses: actions/checkout@v7
+      - name: Rebuild kime-gha-runner with the current devshell
+        run: KIME_REPO="$GITHUB_WORKSPACE" "$HOME"/actions-runner-docker/build.sh


### PR DESCRIPTION
Automates the maintenance step noted in #765: when files defining the CI devshell (`flake.nix`, `flake.lock`, `shell.nix`, `nix/**`) change on develop, the `arch` host runner rebuilds `kime-gha-runner:latest` via `~/actions-runner-docker/build.sh` (which snapshots the flake files from the pushed tree, tags the old image as `:previous`, and pre-substitutes the new closure through the LAN proxy).

No runner restarts: the ephemeral docker-ci runners resolve `:latest` on every respawn, so each serves at most one more job on the old image — and that job still passes because ci.yaml (#765) falls back to evaluating the repo flake when the baked copies don't match the checkout.

`workflow_dispatch` is included for manual rebuilds; a dispatch run on this branch will be the first job ever executed on the `arch` host runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XznmnFSRcLncfbQoiVoPqU