### PR TITLE
chore: add description to every workspace Cargo.toml

### DIFF
--- a/src/engine/backend/Cargo.toml
+++ b/src/engine/backend/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "kime-engine-backend"
+description = "Shared traits, keycodes, and keymaps for kime engine backends"
 version = "0.1.0"
 authors = ["Riey <creeper844@gmail.com>"]
 edition = "2021"

--- a/src/engine/backends/emoji/Cargo.toml
+++ b/src/engine/backends/emoji/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "kime-engine-backend-emoji"
+description = "Emoji input mode backed by CLDR annotations"
 version = "0.1.0"
 authors = ["Riey <creeper844@gmail.com>"]
 edition = "2021"

--- a/src/engine/backends/hangul/Cargo.toml
+++ b/src/engine/backends/hangul/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "kime-engine-backend-hangul"
+description = "Hangul composition backend (dubeolsik, sebeolsik, custom layouts)"
 version = "0.1.0"
 authors = ["Riey <creeper844@gmail.com>"]
 edition = "2021"

--- a/src/engine/backends/hanja/Cargo.toml
+++ b/src/engine/backends/hanja/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "kime-engine-backend-hanja"
+description = "Hanja conversion mode driven by the candidate window"
 version = "0.1.0"
 authors = ["Riey <creeper844@gmail.com>"]
 edition = "2021"

--- a/src/engine/backends/latin/Cargo.toml
+++ b/src/engine/backends/latin/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "kime-engine-backend-latin"
+description = "Latin backend (Qwerty, Dvorak, Colemak)"
 version = "0.1.0"
 authors = ["Riey <creeper844@gmail.com>"]
 edition = "2021"

--- a/src/engine/backends/math/Cargo.toml
+++ b/src/engine/backends/math/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "kime-engine-backend-math"
+description = "LaTeX-style math symbol input mode"
 version = "0.1.0"
 authors = ["Riey <creeper844@gmail.com>"]
 edition = "2021"

--- a/src/engine/candidate/Cargo.toml
+++ b/src/engine/candidate/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "kime-engine-candidate"
+description = "Client for the kime candidate selection window"
 version = "0.1.0"
 authors = ["Riey <creeper844@gmail.com>"]
 edition = "2021"

--- a/src/engine/config/Cargo.toml
+++ b/src/engine/config/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "kime-engine-config"
+description = "Kime configuration types and config.yaml (de)serialization"
 version = "0.1.0"
 authors = ["Riey <creeper844@gmail.com>"]
 license = "GPL-3.0-or-later"

--- a/src/engine/core/Cargo.toml
+++ b/src/engine/core/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "kime-engine-core"
+description = "Kime input engine: category/mode state machine and hotkey dispatch"
 version = "2.0.0"
 authors = ["Riey <creeper844@gmail.com>"]
 edition = "2021"

--- a/src/engine/dict/Cargo.toml
+++ b/src/engine/dict/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "kime-engine-dict"
+description = "Hanja, math symbol, and emoji annotation dictionaries"
 version = "0.1.0"
 authors = ["Riey <creeper844@gmail.com>"]
 edition = "2021"

--- a/src/frontends/wayland/Cargo.toml
+++ b/src/frontends/wayland/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "kime-wayland"
+description = "Kime Wayland input-method frontend"
 version = "0.1.0"
 authors = ["Riey <creeper844@gmail.com>"]
 edition = "2021"

--- a/src/tools/candidate-window/Cargo.toml
+++ b/src/tools/candidate-window/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "kime-candidate-window"
+description = "Candidate selection popup for hanja conversion"
 version = "0.1.0"
 authors = ["Riey <creeper844@gmail.com>"]
 edition = "2021"

--- a/src/tools/check/Cargo.toml
+++ b/src/tools/check/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "kime-check"
+description = "Diagnoses a kime installation and environment"
 version = "0.1.0"
 authors = ["Riey <creeper844@gmail.com>"]
 edition = "2021"

--- a/src/tools/indicator/Cargo.toml
+++ b/src/tools/indicator/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "kime-indicator"
+description = "Kime system tray indicator showing the current input category"
 version = "0.1.0"
 authors = ["Riey <creeper844@gmail.com>"]
 edition = "2021"

--- a/src/tools/kime/Cargo.toml
+++ b/src/tools/kime/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "kime"
+description = "Kime daemon: runs the XIM, Wayland, and indicator modules"
 version = "0.1.0"
 authors = ["Riey <creeper844@gmail.com>"]
 edition = "2021"

--- a/src/tools/log/Cargo.toml
+++ b/src/tools/log/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "kime-log"
+description = "Logger setup shared by kime binaries"
 version = "0.1.0"
 authors = ["Riey <creeper844@gmail.com>"]
 edition = "2021"

--- a/src/tools/properties_writer/Cargo.toml
+++ b/src/tools/properties_writer/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "properties_writer"
+description = "Build helper that writes Java-style properties files"
 version = "0.1.0"
 authors = ["Riey <creeper844@gmail.com>"]
 edition = "2021"

--- a/src/tools/run_dir/Cargo.toml
+++ b/src/tools/run_dir/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "kime-run-dir"
+description = "Resolves kime's runtime directory"
 version = "0.1.0"
 authors = ["Riey <creeper844@gmail.com>"]
 edition = "2021"

--- a/src/tools/version/Cargo.toml
+++ b/src/tools/version/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "kime-version"
+description = "Version string and CLI argument boilerplate for kime binaries"
 version = "0.1.0"
 authors = ["Riey <creeper844@gmail.com>"]
 edition = "2021"


### PR DESCRIPTION
Adds a `description = "..."` line to every workspace crate `Cargo.toml` that lacked one (19 crates; `kime-engine-capi` and `kime-xim` already had descriptions). One mechanical line per manifest — no restructuring to `[workspace.package]`.

Verified with `cargo metadata --no-deps --format-version 1`: succeeds and every package now reports a non-null description.

Closes #549

https://claude.ai/code/session_01Jd5pDnJDa3XRFKkXdchYMB
