### PR TITLE
fix(engine): volume-key mismapping, zombie candidate windows, silent config fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1877,6 +1877,7 @@ dependencies = [
  "kime-engine-backend-math",
  "kime-engine-config",
  "kime-run-dir",
+ "log",
  "parking_lot",
  "pretty_assertions",
  "serde_yaml",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,9 @@
 ### Improve
 
 * fix(engine): hotkey lookup falls back to the key without its own modifier bit — Wayland delivers a modifier key's press with its own modifier already set (X11 reports the pre-event state), so plain `AltR`/`ControlR` hotkeys never fired in Wayland-native apps (hangul toggle in Konsole and other Qt apps on KDE Plasma). Exact bindings such as `M-AltR` keep priority over the fallback; the redundant `M-AltR` default hotkey from [#719] is removed [#760](https://github.com/Riey/kime/pull/760)
+* fix(engine): volume keys (Mute/VolumeDown/VolumeUp) no longer act as Hangul/Hanja keys — hardware keycodes 121/122/123 were raw evdev values added by mistake; only the real X11 keycodes 130 (`<HNGL>`) and 131 (`<HJCV>`) map now [#603](https://github.com/Riey/kime/issues/603) [#769](https://github.com/Riey/kime/pull/769)
+* fix(engine): reap the candidate window process after killing it so dismissed hanja popups no longer accumulate as zombie (`<defunct>`) processes [#617](https://github.com/Riey/kime/issues/617) [#769](https://github.com/Riey/kime/pull/769)
+* fix(engine): log config file open/parse errors instead of silently falling back to the default config, so a syntax error in `config.yaml` is diagnosable [#656](https://github.com/Riey/kime/issues/656) [#769](https://github.com/Riey/kime/pull/769)
 
 ## 3.2.0
 

--- a/src/engine/backend/src/keycode.rs
+++ b/src/engine/backend/src/keycode.rs
@@ -234,8 +234,8 @@ impl KeyCode {
             108 => Some(Self::AltR),
             133 => Some(Self::SuperL),
             134 => Some(Self::SuperR),
-            122 | 130 => Some(Self::Hangul),
-            121 | 123 | 131 => Some(Self::HangulHanja),
+            130 => Some(Self::Hangul),
+            131 => Some(Self::HangulHanja),
 
             113 => Some(Self::Left),
             114 => Some(Self::Right),
@@ -417,4 +417,24 @@ fn super_keys() {
         "SuperR".parse::<Key>().unwrap(),
         Key::normal(KeyCode::SuperR)
     );
+}
+
+#[test]
+fn hangul_hanja_keys() {
+    // X11 hardware keycodes for Hangul (130, <HNGL>) / Hangul_Hanja (131, <HJCV>).
+    assert_eq!(
+        KeyCode::from_hardware_code(130, false),
+        Some(KeyCode::Hangul)
+    );
+    assert_eq!(
+        KeyCode::from_hardware_code(131, false),
+        Some(KeyCode::HangulHanja)
+    );
+
+    // 121/122/123 are XF86AudioMute/LowerVolume/RaiseVolume in X11 keycode
+    // space (evdev + 8). They were added as raw evdev values by mistake and
+    // must not map to Hangul/HangulHanja, or volume keys trigger the IME.
+    assert_eq!(KeyCode::from_hardware_code(121, false), None);
+    assert_eq!(KeyCode::from_hardware_code(122, false), None);
+    assert_eq!(KeyCode::from_hardware_code(123, false), None);
 }

--- a/src/engine/candidate/src/client.rs
+++ b/src/engine/candidate/src/client.rs
@@ -45,6 +45,9 @@ impl Client {
             Ok(String::from_utf8(self.child.wait_with_output()?.stdout).ok())
         } else {
             self.child.kill()?;
+            // Reap the killed child; otherwise every dismissed candidate
+            // window stays around as a zombie (defunct) process.
+            self.child.wait()?;
             Ok(None)
         }
     }

--- a/src/engine/core/Cargo.toml
+++ b/src/engine/core/Cargo.toml
@@ -15,6 +15,7 @@ kime-engine-backend-math = { path = "../backends/math", optional = true }
 kime-engine-backend-emoji = { path = "../backends/emoji", optional = true }
 serde_yaml = "0.9"
 parking_lot = "0.12"
+log = "0.4"
 fontdb = { version = "0.23", features = ["fontconfig"] }
 
 [target.'cfg(unix)'.dependencies]

--- a/src/engine/core/src/config.rs
+++ b/src/engine/core/src/config.rs
@@ -107,21 +107,45 @@ impl Config {
 }
 
 #[cfg(unix)]
+fn load_raw_config(dir: &xdg::BaseDirectories) -> RawConfig {
+    let Some(path) = dir.find_config_file("config.yaml") else {
+        return RawConfig::default();
+    };
+
+    let file = match std::fs::File::open(&path) {
+        Ok(file) => file,
+        Err(err) => {
+            log::error!(
+                "Can't open config file `{}`, falling back to the default config: {err}",
+                path.display()
+            );
+            return RawConfig::default();
+        }
+    };
+
+    match serde_yaml::from_reader(file) {
+        Ok(config) => config,
+        Err(err) => {
+            log::error!(
+                "Can't parse config file `{}`, falling back to the default config: {err}",
+                path.display()
+            );
+            RawConfig::default()
+        }
+    }
+}
+
+#[cfg(unix)]
 pub fn load_raw_config_from_config_dir() -> RawConfig {
     let dir = xdg::BaseDirectories::with_prefix("kime");
 
-    dir.find_config_file("config.yaml")
-        .and_then(|config| serde_yaml::from_reader(std::fs::File::open(config).ok()?).ok())
-        .unwrap_or_default()
+    load_raw_config(&dir)
 }
 
 #[cfg(unix)]
 pub fn load_engine_config_from_config_dir() -> Option<Config> {
     let dir = xdg::BaseDirectories::with_prefix("kime");
-    let config: RawConfig = dir
-        .find_config_file("config.yaml")
-        .and_then(|config| serde_yaml::from_reader(std::fs::File::open(config).ok()?).ok())
-        .unwrap_or_default();
+    let config = load_raw_config(&dir);
 
     Some(Config::from_engine_config_with_dir(config.engine, &dir))
 }


### PR DESCRIPTION
Three engine bugfixes:

## 1. Volume keys mismapped as Hangul/Hanja keys (#603)

`KeyCode::from_hardware_code` mapped 122 to `Hangul` and 121/123 to `HangulHanja`. All frontends pass X11-space hardware keycodes (evdev + 8), where 121/122/123 are XF86AudioMute / XF86AudioLowerVolume / XF86AudioRaiseVolume — the 121/122/123 arms were raw evdev numbers added by mistake (c6f5cb8, 5e34b2c). With the stock config this made VolumeDown toggle the IME and Mute/VolumeUp open hanja mode. Only the real X11 keycodes remain: 130 (`<HNGL>`) → `Hangul`, 131 (`<HJCV>`) → `HangulHanja`. Added regression tests asserting 121/122/123 no longer map and 130/131 still do.

## 2. Zombie candidate-window processes

`candidate::Client::close()` called `child.kill()` without reaping, so every dismissed hanja popup stayed around as a `<defunct>` process for the lifetime of the frontend. It now waits on the child after killing it.

References #617 (zombie half; the Qt focus half is a separate PR)

## 3. Silent config parse failures

`load_raw_config_from_config_dir` / `load_engine_config_from_config_dir` swallowed file-open and YAML-parse errors via `.ok()`, so one syntax error in `config.yaml` silently reverted everything to defaults with no diagnostic. Both loaders now share a helper that logs the error (path + cause) via the `log` crate while still falling back to defaults; function signatures are unchanged.

References #656 (silent config fallback)

Closes #603

## Verification

- `cargo test --workspace` passes
- `cargo fmt --check` and `cargo clippy` clean on touched code

https://claude.ai/code/session_01Jd5pDnJDa3XRFKkXdchYMB