### PR TITLE
chore: misc cleanups (autostart typo, changelog links, ubuntu-22.04 docker)

### DIFF
--- a/build-docker/ubuntu-22.04/Dockerfile
+++ b/build-docker/ubuntu-22.04/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive \
   PATH=/root/.cargo/bin:$PATH
-ENV MESON_ARGS="-Dgtk3=enabled -Dgtk4=disabled -Dqt5=enabled -Dqt6=disabled"
+ENV MESON_ARGS="-Dgtk3=enabled -Dgtk4=enabled -Dqt5=enabled -Dqt6=enabled"
 
 WORKDIR /opt/kime
 
@@ -11,8 +11,9 @@ RUN apt-get install -y curl apt-utils
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --no-modify-path --profile minimal
 RUN rustc --version
 RUN apt-get install -y build-essential git gcc libclang-11-dev ninja-build pkg-config zstd meson
-RUN apt-get install -y libpango1.0-dev libcairo2-dev libgtk-3-dev libglib2.0 libxcb1
+RUN apt-get install -y libpango1.0-dev libcairo2-dev libgtk-4-dev libgtk-3-dev libglib2.0 libxcb1
 RUN apt-get install -y qtbase5-dev qtbase5-private-dev libqt5gui5
+RUN apt-get install -y qt6-base-dev qt6-base-private-dev
 RUN apt-get install -y libxcb-shape0-dev libxcb-xfixes0-dev
 RUN mkdir -pv /opt/kime-out
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,11 +29,11 @@
 * Fix mismatched cargoDeps in nix and update attribute syntax **[@nakoo]**
 * Updated NixOS configuration example to match updated attribute syntax.
 * Remove `kime-engine-cffi`
-* fix(wayland input_method_v2): not return unwarp **[@racakenon]** [#715](https://github.com/Riey/kime/715)
-* feat(engine): Let default `Alt_R` hotkey accept `Alt` modifier [#719](https://github.com/Riey/kime/719)
-* fix(hangul): Don't consume pass keys (numbers, symbols) so app shortcuts like `@`/`#` fire in Hangul mode [#719](https://github.com/Riey/kime/719)
+* fix(wayland input_method_v2): not return unwarp **[@racakenon]** [#715](https://github.com/Riey/kime/pull/715)
+* feat(engine): Let default `Alt_R` hotkey accept `Alt` modifier [#719](https://github.com/Riey/kime/issues/719)
+* fix(hangul): Don't consume pass keys (numbers, symbols) so app shortcuts like `@`/`#` fire in Hangul mode [#719](https://github.com/Riey/kime/issues/719)
 * Add Opensuse Build Service repository and modify README
-* fix(xim): handle None from from_hardware_code without panic [#721](https://github.com/Riey/kime/721)
+* fix(xim): handle None from from_hardware_code without panic [#721](https://github.com/Riey/kime/issues/721)
 * Update dependencies:
   - wayland-client 0.29 → 0.31, wayland-protocols 0.29 → 0.32
   - wayland-protocols-misc 0.3 (신규), xdg 2.5 → 3.0, quick-xml 0.27 → 0.39

--- a/res/kime-xdg-autostart
+++ b/res/kime-xdg-autostart
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-/usr/bin/kime "#@"
+/usr/bin/kime "$@"
 if systemctl --user is-active --quiet app-kime@autostart.service; then
 	sleep 7s
 fi


### PR DESCRIPTION
Three unrelated small cleanups:

- **`res/kime-xdg-autostart`**: the daemon was launched as `/usr/bin/kime "#@"` — a typo for `"$@"`, so a literal `#@` argument was passed instead of forwarding the script's arguments. Fixed to `"$@"`.
- **`docs/CHANGELOG.md`**: several 3.2.0 entries had malformed GitHub links missing the `/issues/` or `/pull/` path segment. Verified each number against the GitHub API: [#715](https://github.com/Riey/kime/pull/715) is a PR (`/pull/715`), [#719](https://github.com/Riey/kime/issues/719) and [#721](https://github.com/Riey/kime/issues/721) are issues (`/issues/719`, `/issues/721`). No entry wording changed.
- **`build-docker/ubuntu-22.04/Dockerfile`**: still configured with `-Dgtk4=disabled -Dqt6=disabled`, while the release workflow's ubuntu-22.04 deb job (cf. #750) builds with all four toolkits enabled. Aligned the Dockerfile: enabled gtk4/qt6 in `MESON_ARGS` and added `libgtk-4-dev`, `qt6-base-dev`, `qt6-base-private-dev`, mirroring the release workflow and the ubuntu-24.04 Dockerfile. No comment in the Dockerfile explained the divergence.

Note (pre-existing, not touched here): the ubuntu-22.04 Dockerfile installs meson from apt (0.61), but `meson.build` requires `>= 1.1` — the release workflow works around this with a pip-installed meson.

No changelog entries (chore).

https://claude.ai/code/session_01Jd5pDnJDa3XRFKkXdchYMB