### PR TITLE
fix(qt): track NOT_READY so focus loss to the candidate window doesn't reset the engine

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Improve
 
+* fix(qt): track `NOT_READY` so focus loss to the hanja candidate window no longer resets the engine and kills the popup [#757](https://github.com/Riey/kime/issues/757) [#771](https://github.com/Riey/kime/pull/771)
 * fix(engine): hotkey lookup falls back to the key without its own modifier bit — Wayland delivers a modifier key's press with its own modifier already set (X11 reports the pre-event state), so plain `AltR`/`ControlR` hotkeys never fired in Wayland-native apps (hangul toggle in Konsole and other Qt apps on KDE Plasma). Exact bindings such as `M-AltR` keep priority over the fallback; the redundant `M-AltR` default hotkey from [#719] is removed [#760](https://github.com/Riey/kime/pull/760)
 
 ## 3.2.0

--- a/src/frontends/qt5/src/input_context.cc
+++ b/src/frontends/qt5/src/input_context.cc
@@ -121,6 +121,13 @@ void KimeInputContext::commit_str(kime::RustStr s) {
 }
 
 bool KimeInputContext::process_input_result(kime::InputResult ret) {
+  if (ret & kime::InputResult_NOT_READY) {
+    // The engine is waiting for the candidate window process (e.g. hanja
+    // conversion). Mark it not ready so losing focus to that window does
+    // not reset the engine and kill the popup (issue #757).
+    this->engine_ready = false;
+  }
+
   if (ret & kime::InputResult_LANGUAGE_CHANGED) {
     kime::kime_engine_update_layout_state(this->engine);
   }


### PR DESCRIPTION
## Root cause

In Qt/KDE apps the hanja candidate popup appeared and instantly vanished, and the syllable being converted was deleted (GTK apps were fine):

1. When hanja mode spawns the external `kime-candidate-window` process, the engine reports `InputResult::NOT_READY` (`src/engine/core/src/lib.rs`, `current_result`).
2. The GTK (`src/frontends/gtk3/src/immodule.c`), XIM (`src/frontends/xim/src/handler.rs`) and Wayland (`src/frontends/wayland/src/state.rs`) frontends track this flag in an `engine_ready` state and suppress reset-on-focus-loss while it is unset.
3. The Qt frontend never did: `KimeInputContext::process_input_result` had no `NOT_READY` branch, and `engine_ready` (initialized `true`) was never written.
4. So when the candidate window took focus, `setFocusObject(nullptr)` passed the `focus_object && engine_ready` guard and ran `reset()`, which resets the engine → `HanjaMode::reset` → `Client::close()` kills the just-spawned candidate window (`src/engine/candidate/src/client.rs`), and `kime_engine_clear_preedit` discards the syllable.

## Fix

Mirror the GTK logic in `process_input_result`: when the result carries `kime::InputResult_NOT_READY`, set `engine_ready = false`. The existing `check_ready`/`end_ready` handling in `setFocusObject` already restores the state (and processes the selected candidate) when focus returns, so no other change is needed. The file is shared by the qt5 and qt6 builds.

## Testing

- Built the Qt frontend with meson/ninja: both `qt5` and `qt6` `libkimeplatforminputcontextplugin.so` compile and link cleanly with the change.
- `cargo test --workspace` passes (engine untouched).
- Not runtime-tested against a live KDE Wayland session; the flow matches the GTK frontend's, which is confirmed working in the issue report.

Closes #757

References #695, #617, #545 (same focus-kill mechanism)

https://claude.ai/code/session_01Jd5pDnJDa3XRFKkXdchYMB