### PR TITLE
docs: document input modes, hotkey key format and candidate_font

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Improve
 
+* docs: document the Math/Hanja/Emoji input modes, the hotkey key format and `candidate_font`; fix the documented `xim_preedit_font` default (`Noto Sans CJK KR`, not `D2Coding`) [#671](https://github.com/Riey/kime/issues/671) [#583](https://github.com/Riey/kime/issues/583) [#572](https://github.com/Riey/kime/issues/572) [#773](https://github.com/Riey/kime/pull/773)
 * fix(engine): hotkey lookup falls back to the key without its own modifier bit — Wayland delivers a modifier key's press with its own modifier already set (X11 reports the pre-event state), so plain `AltR`/`ControlR` hotkeys never fired in Wayland-native apps (hangul toggle in Konsole and other Qt apps on KDE Plasma). Exact bindings such as `M-AltR` keep priority over the fallback; the redundant `M-AltR` default hotkey from [#719] is removed [#760](https://github.com/Riey/kime/pull/760)
 
 ## 3.2.0

--- a/docs/CONFIGURATION.ko.md
+++ b/docs/CONFIGURATION.ko.md
@@ -79,6 +79,44 @@ indicator에서 사용할 아이콘의 색을 정합니다
 
 엔진의 단축키를 설정합니다 형식은 `키: 내용` 입니다
 
+### 키 형식
+
+키는 0개 이상의 수식키 접두사 뒤에 키 이름을 이어서 적습니다.
+
+| 접두사   | 수식키                        |
+|----------|-------------------------------|
+| `Super-` | Super (윈도우/로고 키)        |
+| `M-`     | Alt (Emacs의 Meta에서 온 `M`) |
+| `C-`     | Ctrl                          |
+| `S-`     | Shift                         |
+
+접두사는 순서에 상관없이 조합할 수 있으며, kime가 출력할 때는 `Super-`,
+`M-`, `C-`, `S-` 순서로 적습니다.
+
+예시:
+
+* `S-Space` — Shift+Space
+* `M-C-Backslash` — Alt+Ctrl+`\`
+* `Super-Space` — Super+Space
+
+사용할 수 있는 키 이름:
+
+* 숫자: `1`-`9`, `0`
+* 숫자패드 숫자(NumLock 켜짐): `N1`-`N9`, `N0`
+* 로마자: `A`-`Z`
+* `Minus`, `Equal`, `Backslash`, `Grave`, `OpenBracket`, `CloseBracket`,
+  `Space`, `Comma`, `Period`, `SemiColon`, `Quote`, `Slash`
+* `Esc`, `Shift`, `Backspace`, `Enter`, `Tab`, `ControlL`, `ControlR`,
+  `Delete`, `Insert`, `Home`, `End`, `PageUp`, `PageDown`, `Muhenkan`,
+  `Henkan`, `AltL`, `AltR`, `SuperL`, `SuperR`, `Hangul`, `HangulHanja`
+* 방향키: `Left`, `Right`, `Up`, `Down`
+* 기능키: `F1`-`F12`
+
+`Shift`는 좌우 구분이 없는 단일 키 이름이고 Ctrl, Alt, Super는
+`ControlL`/`ControlR`, `AltL`/`AltR`, `SuperL`/`SuperR`로 좌우가
+구분됩니다. 수식키 자체도 단축키로 지정할 수 있습니다(기본 설정의
+`AltR`, `ControlR`처럼).
+
 ### global_hotkeys
 
 전역 단축키입니다
@@ -105,7 +143,8 @@ indicator에서 사용할 아이콘의 색을 정합니다
 
 ##### !Mode InputMode
 
-해당 모드를 활성화합니다
+해당 모드를 활성화합니다 각 모드의 동작은 [입력 모드](#입력-모드)를
+참고하세요
 
 ##### Commit
 
@@ -133,7 +172,15 @@ indicator에서 사용할 아이콘의 색을 정합니다
 
 XIM에서 쓸 편집창 글꼴과 크기입니다.
 
-| 기본값 |`[D2Coding, 15.0]`|
+| 기본값 |`[Noto Sans CJK KR, 15.0]`|
+|--------|--------------------------|
+
+## candidate_font
+
+[Hanja 모드](#hanja)에서 쓰는 `kime-candidate-window` 팝업의 글꼴
+이름입니다.
+
+| 기본값 |`Noto Sans CJK KR`|
 |--------|------------------|
 
 ## latin
@@ -279,3 +326,73 @@ sebeolsik-3sin-p2:
 ```
 
 ##### DecomposeJongseongSsang
+
+# 입력 모드
+
+kime에는 `Latin`/`Hangul` 입력 언어 외에 세 가지 입력 *모드*가
+있습니다: `Math`, `Hanja`, `Emoji`. 모드는 `!Mode`
+단축키([hotkeys](#hotkeys) 참고)로 켜지며 현재 언어 위에서 동작합니다.
+
+기본 단축키:
+
+| 모드    | 기본 단축키                     | 사용 범위          |
+|---------|---------------------------------|--------------------|
+| `Math`  | `M-C-Backslash` (Alt+Ctrl+`\`)  | 전역               |
+| `Emoji` | `M-C-E` (Alt+Ctrl+E)            | 전역               |
+| `Hanja` | `F9`, `HangulHanja`, `ControlR` | `Hangul` 언어에서만 |
+
+모든 모드에서 `Enter`와 `Tab`이 기본으로 `Commit`에 연결되어 있어 현재
+입력을 커밋합니다. 전역 단축키는 `mode_hotkeys`에서 덮어쓰지 않는 한
+모드 안에서도 계속 동작하므로, 예를 들어 기본 `Esc` 단축키(`!Switch
+Latin`)로 모드에서 빠져나올 수 있습니다.
+
+## Math
+
+수학 기호를 (대부분) LaTeX 이름으로 입력하는 모드입니다. 이 모드는
+지속되는 모드로, 기호를 커밋한 뒤에도 언어를 바꾸기 전까지(예:
+`Esc`나 한영 전환키) 유지됩니다.
+
+* `\`로 기호 이름 입력을 시작합니다. 이름을 입력한 뒤
+  `Enter`/`Tab`으로 커밋합니다: `\pi` → π, `\Pi` → Π (이름은
+  대소문자를 구분합니다).
+* 기호 이름을 입력 중이 아닐 때 누른 키는 일반 로마자로 커밋됩니다.
+* `\\`는 백슬래시 `\` 문자를 커밋합니다.
+* `Backspace`는 이름의 마지막 글자를 지우며, 이름이 비어 있으면 기호
+  입력을 종료합니다.
+* 이름 앞에 `\<스타일>.<이름>` 형식으로 스타일을 붙일 수 있습니다.
+  스타일은 `sf`(산세리프), `bf`(굵게), `it`(기울임), `tt`(고정폭),
+  `bb`(겹선), `scr`(스크립트), `cal`(필기체), `frak`(프락투어)이며
+  순서에 상관없이 이어 붙일 수 있습니다: `\bfit.alpha` → 𝜶.
+* 없는 이름은 아무것도 커밋하지 않습니다. 해석할 수 없는 스타일은
+  조용히 무시되고 스타일 없는 기호가 커밋됩니다.
+* LaTeX에 없는 이름도 일부 있습니다. 예: `\squotl` → 「. 전체 목록은
+  [symbol_map.json]을 보세요.
+
+[symbol_map.json]: ../src/engine/dict/data/symbol_map.json
+
+## Emoji
+
+이모지를 이름으로 검색해 입력하는 모드입니다.
+
+* 이모지의 영어 이름 일부를 입력하세요 — 영어 [유니코드 CLDR][cldr]
+  이름에 대한 부분 문자열 검색이므로 한글 이름으로는 검색되지
+  않습니다.
+* 편집창에 검색어와 함께 일치하는 후보가 최대 5개 표시됩니다.
+* `Space`도 검색어의 일부입니다(예: `red apple`).
+* `Enter`/`Tab`은 첫 번째 후보를 커밋하고 모드를 종료합니다.
+* `Backspace`는 검색어의 마지막 글자를 지우며, 검색어가 비어 있으면
+  모드를 종료합니다.
+
+[cldr]: https://cldr.unicode.org
+
+## Hanja
+
+조합 중인 한글을 한자로 변환하는 모드로, `Hangul` 언어에서 편집 중인
+글자가 있을 때만 동작합니다(예: 한을 입력한 뒤 `F9`).
+
+* 후보와 뜻을 보여주는 `kime-candidate-window` 팝업이 열립니다.
+  `kime-candidate-window` 바이너리가 `PATH`에 설치되어 있어야 합니다.
+* 마우스로 후보를 클릭하면 커밋되고, `Esc`를 누르면 변환 없이
+  닫힙니다.
+
+팝업의 키보드 조작은 아직 미비하며 개편 중입니다.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -78,6 +78,44 @@ Set category state globally
 
 Set engine hotkey format is `Key: Content`
 
+### Key format
+
+A key is written as zero or more modifier prefixes followed by a key name.
+
+| prefix   | modifier                     |
+|----------|------------------------------|
+| `Super-` | Super (Windows/logo key)     |
+| `M-`     | Alt (`M` as in Emacs' Meta)  |
+| `C-`     | Ctrl                         |
+| `S-`     | Shift                        |
+
+Prefixes can be combined in any order; kime itself prints them in the
+order `Super-`, `M-`, `C-`, `S-`.
+
+Examples:
+
+* `S-Space` — Shift+Space
+* `M-C-Backslash` — Alt+Ctrl+`\`
+* `Super-Space` — Super+Space
+
+Available key names:
+
+* digits: `1`-`9`, `0`
+* numpad digits (NumLock on): `N1`-`N9`, `N0`
+* letters: `A`-`Z`
+* `Minus`, `Equal`, `Backslash`, `Grave`, `OpenBracket`, `CloseBracket`,
+  `Space`, `Comma`, `Period`, `SemiColon`, `Quote`, `Slash`
+* `Esc`, `Shift`, `Backspace`, `Enter`, `Tab`, `ControlL`, `ControlR`,
+  `Delete`, `Insert`, `Home`, `End`, `PageUp`, `PageDown`, `Muhenkan`,
+  `Henkan`, `AltL`, `AltR`, `SuperL`, `SuperR`, `Hangul`, `HangulHanja`
+* arrow keys: `Left`, `Right`, `Up`, `Down`
+* function keys: `F1`-`F12`
+
+Note that `Shift` is a single key name without left/right variants while
+Ctrl, Alt and Super come as `ControlL`/`ControlR`, `AltL`/`AltR`,
+`SuperL`/`SuperR`. Modifier keys themselves can also be bound as hotkeys
+(e.g. the default `AltR` and `ControlR` bindings).
+
 ### global_hotkeys
 
 Global hotkey
@@ -104,7 +142,8 @@ Switch to specific category
 
 ##### !Mode InputMode
 
-Enable specific mode
+Enable specific mode, see [Input modes](#input-modes) for what each mode
+does
 
 ##### Commit
 
@@ -132,7 +171,15 @@ When hotkey processed it act like Consume otherwise it act like Bypass
 
 Preedit window font name and size for XIM
 
-| default |`[D2Coding, 15.0]`|
+| default |`[Noto Sans CJK KR, 15.0]`|
+|---------|--------------------------|
+
+## candidate_font
+
+Font name for the `kime-candidate-window` popup used by
+[Hanja mode](#hanja)
+
+| default |`Noto Sans CJK KR`|
 |---------|------------------|
 
 ## latin
@@ -294,3 +341,78 @@ Same as above but work on backspace(e.g. ㄲ -> ㄱ)
 ```
 
 #### DecomposeJongseongSsang
+
+# Input modes
+
+Besides the `Latin`/`Hangul` input categories kime has three input
+*modes*: `Math`, `Hanja` and `Emoji`. A mode is entered with a `!Mode`
+hotkey (see [hotkeys](#hotkeys)) and works on top of the current
+category.
+
+Default hotkeys:
+
+| mode    | default hotkey                  | available in            |
+|---------|---------------------------------|-------------------------|
+| `Math`  | `M-C-Backslash` (Alt+Ctrl+`\`)  | everywhere              |
+| `Emoji` | `M-C-E` (Alt+Ctrl+E)            | everywhere              |
+| `Hanja` | `F9`, `HangulHanja`, `ControlR` | `Hangul` category only  |
+
+In every mode `Enter` and `Tab` are bound to `Commit` by default, which
+commits the current input. Global hotkeys keep working inside a mode
+unless overridden in `mode_hotkeys`, so for example the default `Esc`
+hotkey (`!Switch Latin`) also leaves a mode.
+
+## Math
+
+Math mode inputs Unicode math symbols by (mostly) LaTeX names. The mode
+is persistent: it stays active after committing a symbol until you
+switch category (e.g. `Esc` or the hangul toggle key).
+
+* `\` starts a symbol name. Type the name, then commit with
+  `Enter`/`Tab`: `\pi` → π, `\Pi` → Π (names are case-sensitive).
+* Keys typed while no symbol name is open are committed as normal latin
+  characters.
+* `\\` commits a literal backslash `\`.
+* `Backspace` removes the last character of the name; when the name is
+  empty it closes symbol entry.
+* A style prefix can be put before the name as `\<style>.<name>`. The
+  styles are `sf` (sans-serif), `bf` (bold), `it` (italic), `tt`
+  (monospace), `bb` (double-struck), `scr` (script), `cal`
+  (calligraphic) and `frak` (fraktur), and they can be concatenated in
+  any order: `\bfit.alpha` → 𝜶.
+* An unknown name commits nothing. An unparsable style prefix is
+  silently ignored and the unstyled symbol is committed instead.
+* Some non-LaTeX names also exist, e.g. `\squotl` → 「. See
+  [symbol_map.json] for the full list.
+
+[symbol_map.json]: ../src/engine/dict/data/symbol_map.json
+
+## Emoji
+
+Emoji mode searches emoji by name.
+
+* Type part of the emoji's English name — candidates are matched by
+  substring against the English [Unicode CLDR][cldr] annotation names,
+  so Korean input won't match anything.
+* The preedit shows the query followed by up to 5 matching candidates.
+* `Space` is part of the query (e.g. `red apple`).
+* `Enter`/`Tab` commits the first candidate and leaves the mode.
+* `Backspace` removes the last character of the query; when the query is
+  empty it leaves the mode.
+
+[cldr]: https://cldr.unicode.org
+
+## Hanja
+
+Hanja mode converts the hangul text you are composing into hanja, so it
+only works in the `Hangul` category while a preedit exists (e.g. type 한
+then press `F9`).
+
+* It opens the `kime-candidate-window` popup listing the candidates with
+  their meanings. The `kime-candidate-window` binary must be installed
+  in `PATH`.
+* Click a candidate with the mouse to commit it; `Esc` closes the popup
+  without converting.
+
+The popup's keyboard handling is currently minimal and is being
+reworked.


### PR DESCRIPTION
Documents the parts of `config.yaml` that were missing from `docs/CONFIGURATION.md` / `docs/CONFIGURATION.ko.md` (both files kept in sync):

* **New "Input modes" section** covering the three `InputMode` values, verified against the engine sources:
  * default hotkeys (`Math` = `M-C-Backslash`, `Emoji` = `M-C-E` globally; `Hanja` = `F9`/`HangulHanja`/`ControlR` in the `Hangul` category; `Enter`/`Tab` = `Commit` in every mode) and the fact that global hotkeys keep working inside a mode, so `Esc` leaves it
  * **Math**: persistent mode, `\name` + `Enter`/`Tab`, `\\` for a literal backslash, Backspace behavior, style prefixes `\<style>.<name>` (`sf bf it tt bb scr cal frak`, combinable e.g. `\bfit.alpha` → 𝜶), non-LaTeX extras (`\squotl` → 「), and that an unparsable style prefix silently falls back to the unstyled symbol
  * **Emoji**: English CLDR-name substring search, up to 5 candidates in the preedit, Space as part of the query, Enter/Tab commits the first candidate, Backspace on an empty query exits
  * **Hanja**: converts the current hangul preedit, opens the `kime-candidate-window` popup (binary must be on `PATH`), mouse click selects, `Esc` cancels — key handling kept intentionally brief since the popup is being reworked
  * the `!Mode InputMode` hotkey behavior entry now links to this section
* **New "Key format" subsection** under `hotkeys`: modifier prefixes (`Super-`, `M-`, `C-`, `S-`, any order, canonical output order noted), the full `KeyCode` name list, worked examples (`S-Space`, `M-C-Backslash`, `Super-Space`), and a note that `Shift` has no L/R variants while Ctrl/Alt/Super do and that modifier keys themselves can be hotkeys
* **Document `candidate_font`** (default `Noto Sans CJK KR`), which was missing entirely
* **Fix the `xim_preedit_font` default**: docs claimed `[D2Coding, 15.0]` but the actual default is `[Noto Sans CJK KR, 15.0]`

Closes #671
Closes #583
Closes #572

https://claude.ai/code/session_01Jd5pDnJDa3XRFKkXdchYMB