### PR TITLE
feat(engine): add a format version to layout files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1797,6 +1797,7 @@ version = "0.1.0"
 dependencies = [
  "enumset",
  "kime-engine-backend",
+ "log",
  "num-derive",
  "num-traits",
  "serde",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Improve
 
 * fix(engine): hotkey lookup falls back to the key without its own modifier bit — Wayland delivers a modifier key's press with its own modifier already set (X11 reports the pre-event state), so plain `AltR`/`ControlR` hotkeys never fired in Wayland-native apps (hangul toggle in Konsole and other Qt apps on KDE Plasma). Exact bindings such as `M-AltR` keep priority over the fallback; the redundant `M-AltR` default hotkey from [#719] is removed [#760](https://github.com/Riey/kime/pull/760)
+* feat(engine): layout files support an optional `version:`/`keys:` format — files declaring a format version newer than kime supports are rejected with a clear error instead of breaking silently on a future format change, legacy flat-map layouts keep working unchanged, and user layout files that fail to load are logged with the reason instead of silently skipped [#540](https://github.com/Riey/kime/issues/540) [#774](https://github.com/Riey/kime/pull/774)
 
 ## 3.2.0
 

--- a/src/engine/backends/hangul/Cargo.toml
+++ b/src/engine/backends/hangul/Cargo.toml
@@ -8,6 +8,7 @@ license = "GPL-3.0-or-later"
 [dependencies]
 kime-engine-backend = { path = "../../backend" }
 enumset = "1.1"
+log = "0.4"
 num-derive = "0.4"
 num-traits = "0.2"
 serde = { version = "1.0", features = ["derive"] }

--- a/src/engine/backends/hangul/src/layout.rs
+++ b/src/engine/backends/hangul/src/layout.rs
@@ -61,6 +61,17 @@ struct VersionProbe {
     version: Option<u32>,
 }
 
+impl VersionProbe {
+    /// The format version this file is written in.
+    ///
+    /// A file without a `version` field is format version 1: the original
+    /// flat-map format predates the field, so its absence is semantically
+    /// identical to `version: 1` (not merely "legacy accepted").
+    fn format_version(&self) -> u32 {
+        self.version.unwrap_or(1)
+    }
+}
+
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 struct VersionedLayout {
@@ -96,18 +107,20 @@ impl Layout {
         // also checks the version before the rest of the file is parsed: a
         // future format may change the schema, and the unsupported version
         // error is more useful than a schema mismatch.
-        let items: HashMap<Key, String> =
-            match serde_yaml::from_str::<VersionProbe>(content)?.version {
-                Some(version) => {
-                    if version > LAYOUT_FORMAT_VERSION {
-                        return Err(LayoutError::UnsupportedVersion { version });
-                    }
+        let probe: VersionProbe = serde_yaml::from_str(content)?;
+        let version = probe.format_version();
 
-                    serde_yaml::from_str::<VersionedLayout>(content)?.keys
-                }
-                // Legacy format: a flat `Key: value` map without a version field.
-                None => serde_yaml::from_str(content)?,
-            };
+        if version > LAYOUT_FORMAT_VERSION {
+            return Err(LayoutError::UnsupportedVersion { version });
+        }
+
+        let items: HashMap<Key, String> = if probe.version.is_some() {
+            serde_yaml::from_str::<VersionedLayout>(content)?.keys
+        } else {
+            // Legacy shape: a flat `Key: value` map without a version field,
+            // read as format version 1.
+            serde_yaml::from_str(content)?
+        };
 
         Ok(Self::from_items(items))
     }
@@ -159,6 +172,32 @@ keys:
 
     #[test]
     fn versioned_layout_parses_like_flat() {
+        let flat = Layout::load_from(FLAT).expect("flat layout parses");
+        let versioned = Layout::load_from(VERSIONED).expect("versioned layout parses");
+
+        for key in KEYS {
+            assert_eq!(
+                flat.lookup_kv(key),
+                versioned.lookup_kv(key),
+                "mismatch for key {key}"
+            );
+        }
+    }
+
+    #[test]
+    fn missing_version_is_treated_as_version_1() {
+        // The defaulting decision itself: a file without a `version` field
+        // resolves to format version 1, not merely "legacy accepted".
+        let probe: VersionProbe = serde_yaml::from_str(FLAT).expect("flat layout probes");
+        assert_eq!(probe.version, None);
+        assert_eq!(probe.format_version(), 1);
+
+        let probe: VersionProbe = serde_yaml::from_str(VERSIONED).expect("versioned layout probes");
+        assert_eq!(probe.version, Some(1));
+        assert_eq!(probe.format_version(), 1);
+
+        // And end to end: the same key set with and without `version: 1`
+        // produces identical layouts.
         let flat = Layout::load_from(FLAT).expect("flat layout parses");
         let versioned = Layout::load_from(VERSIONED).expect("versioned layout parses");
 

--- a/src/engine/backends/hangul/src/layout.rs
+++ b/src/engine/backends/hangul/src/layout.rs
@@ -1,7 +1,73 @@
 use crate::characters::KeyValue;
 use crate::Key;
 use kime_engine_backend::KeyMap;
+use serde::Deserialize;
 use std::collections::HashMap;
+
+/// The newest layout file format version this version of kime understands.
+///
+/// Version 1 is the versioned form of the original flat-map format:
+///
+/// ```yaml
+/// version: 1
+/// keys:
+///   Q: ㅂ
+/// ```
+///
+/// Files without a `version` field keep being parsed as the legacy flat map.
+pub const LAYOUT_FORMAT_VERSION: u32 = 1;
+
+#[derive(Debug)]
+pub enum LayoutError {
+    /// The file is not valid YAML or doesn't match the layout schema.
+    Parse(serde_yaml::Error),
+    /// The file declares a format version newer than this kime supports.
+    UnsupportedVersion { version: u32 },
+}
+
+impl std::fmt::Display for LayoutError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Parse(err) => err.fmt(f),
+            Self::UnsupportedVersion { version } => write!(
+                f,
+                "layout format version {} is not supported, this version of kime supports up to version {}",
+                version, LAYOUT_FORMAT_VERSION
+            ),
+        }
+    }
+}
+
+impl std::error::Error for LayoutError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Parse(err) => Some(err),
+            Self::UnsupportedVersion { .. } => None,
+        }
+    }
+}
+
+impl From<serde_yaml::Error> for LayoutError {
+    fn from(err: serde_yaml::Error) -> Self {
+        Self::Parse(err)
+    }
+}
+
+/// Probe that only extracts the `version` field, ignoring everything else,
+/// so the version can be checked before the rest of the file is parsed.
+#[derive(Deserialize)]
+struct VersionProbe {
+    #[serde(default)]
+    version: Option<u32>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct VersionedLayout {
+    #[allow(dead_code)]
+    version: u32,
+    keys: HashMap<Key, String>,
+}
 
 #[derive(Clone, Default)]
 pub struct Layout {
@@ -24,12 +90,113 @@ impl Layout {
         Self { keymap }
     }
 
-    pub fn load_from(content: &str) -> Result<Self, serde_yaml::Error> {
-        Ok(Self::from_items(serde_yaml::from_str(content)?))
+    pub fn load_from(content: &str) -> Result<Self, LayoutError> {
+        // Two-step parse so each shape reports its own error instead of the
+        // vague "did not match any variant" from an untagged enum. The probe
+        // also checks the version before the rest of the file is parsed: a
+        // future format may change the schema, and the unsupported version
+        // error is more useful than a schema mismatch.
+        let items: HashMap<Key, String> =
+            match serde_yaml::from_str::<VersionProbe>(content)?.version {
+                Some(version) => {
+                    if version > LAYOUT_FORMAT_VERSION {
+                        return Err(LayoutError::UnsupportedVersion { version });
+                    }
+
+                    serde_yaml::from_str::<VersionedLayout>(content)?.keys
+                }
+                // Legacy format: a flat `Key: value` map without a version field.
+                None => serde_yaml::from_str(content)?,
+            };
+
+        Ok(Self::from_items(items))
     }
 
     #[inline]
     pub fn lookup_kv(&self, key: Key) -> Option<KeyValue> {
         self.keymap.get(key)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kime_engine_backend::KeyCode;
+
+    // `1: 1` covers keys and values that YAML would otherwise read as
+    // numbers instead of strings (cf. the number row in dubeolsik.yaml).
+    const FLAT: &str = "
+Q: ㅂ$ㅂ
+S-Q: ㅃ
+W: ㅈ
+1: 1
+";
+
+    const VERSIONED: &str = "
+version: 1
+keys:
+  Q: ㅂ$ㅂ
+  S-Q: ㅃ
+  W: ㅈ
+  1: 1
+";
+
+    const KEYS: [Key; 4] = [
+        Key::normal(KeyCode::Q),
+        Key::shift(KeyCode::Q),
+        Key::normal(KeyCode::W),
+        Key::normal(KeyCode::One),
+    ];
+
+    #[test]
+    fn flat_legacy_layout_parses() {
+        let layout = Layout::load_from(FLAT).expect("flat legacy layout must keep parsing");
+
+        for key in KEYS {
+            assert!(layout.lookup_kv(key).is_some(), "missing key {key}");
+        }
+    }
+
+    #[test]
+    fn versioned_layout_parses_like_flat() {
+        let flat = Layout::load_from(FLAT).expect("flat layout parses");
+        let versioned = Layout::load_from(VERSIONED).expect("versioned layout parses");
+
+        for key in KEYS {
+            assert_eq!(
+                flat.lookup_kv(key),
+                versioned.lookup_kv(key),
+                "mismatch for key {key}"
+            );
+        }
+    }
+
+    #[test]
+    fn future_version_is_rejected() {
+        let err = Layout::load_from("version: 99\nkeys:\n  Q: ㅂ\n")
+            .err()
+            .expect("future format version must be rejected");
+
+        assert!(
+            matches!(err, LayoutError::UnsupportedVersion { version: 99 }),
+            "unexpected error: {err:?}"
+        );
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("99"),
+            "error must name the file version: {msg}"
+        );
+        assert!(
+            msg.contains(&LAYOUT_FORMAT_VERSION.to_string()),
+            "error must name the supported version: {msg}"
+        );
+    }
+
+    #[test]
+    fn builtin_layouts_all_parse() {
+        for (name, content) in crate::BUILTIN_LAYOUTS {
+            Layout::load_from(content).unwrap_or_else(|err| panic!("{name}: {err}"));
+        }
     }
 }

--- a/src/engine/backends/hangul/src/lib.rs
+++ b/src/engine/backends/hangul/src/lib.rs
@@ -8,7 +8,7 @@ use enumset::{EnumSet, EnumSetType};
 use kime_engine_backend::{InputEngineBackend, Key, KeyCode};
 use serde::{Deserialize, Serialize};
 
-pub use layout::Layout;
+pub use layout::{Layout, LayoutError, LAYOUT_FORMAT_VERSION};
 pub use state::HangulEngine;
 
 #[derive(Hash, Serialize, Deserialize, Debug, EnumSetType)]
@@ -116,11 +116,23 @@ impl HangulData {
             .list_config_files("layouts")
             .into_iter()
             .filter_map(|path| {
-                let name = path.file_stem()?.to_str()?;
+                let name = path.file_stem()?.to_str()?.to_string();
 
-                Layout::load_from(std::fs::read_to_string(&path).ok()?.as_str())
-                    .ok()
-                    .map(move |l| (name.to_string().into(), l))
+                let content = match std::fs::read_to_string(&path) {
+                    Ok(content) => content,
+                    Err(err) => {
+                        log::error!("Can't read layout file {}: {}", path.display(), err);
+                        return None;
+                    }
+                };
+
+                match Layout::load_from(&content) {
+                    Ok(layout) => Some((name.into(), layout)),
+                    Err(err) => {
+                        log::error!("Can't load layout file {}: {}", path.display(), err);
+                        None
+                    }
+                }
             });
 
         Self::new(config, custom_layouts.chain(builtin_layouts()))


### PR DESCRIPTION
## Summary

Layout YAML files had no format version, so a future format change (e.g. the planned keycode validation / keysym work) would break user layouts silently. This PR introduces an optional versioned layout file format:

```yaml
version: 1
keys:
  Q: ㅂ
```

- `LAYOUT_FORMAT_VERSION` (currently `1`) is exported from the hangul backend.
- Files without a `version` field keep parsing as the legacy flat `Key: value` map — all existing layouts (builtin and user) work untouched.
- The parse is two-step (a version probe, then the matching shape) instead of a serde untagged enum, so each shape reports its own error. The version is checked before the rest of the file is parsed, so a file declaring a newer version gets a clear "layout format version N is not supported, this version of kime supports up to version 1" error even if the future schema differs.
- `HangulData::from_config_with_dir` no longer swallows user layout errors with `.ok()`: unreadable or invalid layout files are logged (`log::error!`) with the path and reason, then skipped as before.

## Tests

- Versioned layout parses identically to its flat equivalent (including number-row scalars like `1: 1`, which YAML reads as integers).
- Flat legacy layout still parses.
- `version: 99` is rejected with an error naming both the file's version and the supported version.
- All builtin layouts parse through the new code path.

`cargo test --workspace` passes.

Closes #540

https://claude.ai/code/session_01Jd5pDnJDa3XRFKkXdchYMB