### PR TITLE
fix(qt): don't reset the engine from commit() while the candidate window is active

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@
 * fix(engine): reap the candidate window process after killing it so dismissed hanja popups no longer accumulate as zombie (`<defunct>`) processes [#617](https://github.com/Riey/kime/issues/617) [#769](https://github.com/Riey/kime/pull/769)
 * fix(engine): log config file open/parse errors instead of silently falling back to the default config, so a syntax error in `config.yaml` is diagnosable [#656](https://github.com/Riey/kime/issues/656) [#769](https://github.com/Riey/kime/pull/769)
 * feat(engine): layout files support an optional `version:`/`keys:` format — files declaring a format version newer than kime supports are rejected with a clear error instead of breaking silently on a future format change, legacy flat-map layouts keep working unchanged, and user layout files that fail to load are logged with the reason instead of silently skipped [#540](https://github.com/Riey/kime/issues/540) [#774](https://github.com/Riey/kime/pull/774)
+* fix(qt): the hanja candidate window no longer dies on focus-out — this completes the [#771] fix, which guarded `setFocusObject` but not `commit()`: Qt calls `commit()` first on focus-out, so the unconditional reset there still killed the just-spawned popup and discarded the syllable being converted. `commit()` now honours the same `engine_ready` guard, leaving normal commit-on-focus-out unchanged [#757](https://github.com/Riey/kime/issues/757) [#779](https://github.com/Riey/kime/issues/779) [#784](https://github.com/Riey/kime/pull/784)
 
 ## 3.2.0
 

--- a/src/frontends/qt5/src/input_context.cc
+++ b/src/frontends/qt5/src/input_context.cc
@@ -13,7 +13,17 @@ KimeInputContext::KimeInputContext(kime::InputEngine *engine,
 
 void KimeInputContext::update(Qt::InputMethodQueries queries) {}
 
-void KimeInputContext::commit() { this->reset(); }
+void KimeInputContext::commit() {
+  // On focus-out Qt calls commit() *before* setFocusObject(nullptr), so the
+  // engine_ready guard there never gets a chance: an unconditional reset()
+  // here kills the just-spawned candidate window and discards the syllable it
+  // is converting (issue #779, residual of #757).
+  if (!this->engine_ready) {
+    return;
+  }
+
+  this->reset();
+}
 
 void KimeInputContext::reset() {
 #ifdef DEBUG


### PR DESCRIPTION
## Bug

Residual of #757 — [#771](https://github.com/Riey/kime/pull/771) is incomplete.

On widget focus-out Qt invokes `QPlatformInputContext::commit()` **before** `setFocusObject(nullptr)`. `KimeInputContext::commit()` called `reset()` unconditionally, so the `engine_ready` guard #771 added to `setFocusObject` never ran: focus moving to the just-spawned `kime-candidate-window` killed the popup and discarded the syllable being converted.

Instrumented trace on develop HEAD (Xvfb/xcb, qt6 plugin): `commit() called` x2 -> `reset` x2 -> `setFocusObject null ready=0`.

## Fix

Guard `commit()` with `engine_ready` — the same condition `setFocusObject` already uses for its focus-out reset. `src/frontends/qt5/src/input_context.cc` is shared by the qt5 and qt6 builds, so both get the fix.

`engine_ready` is `true` except while the engine is waiting on the candidate window process (`InputResult::NOT_READY`, cleared in `process_input_result`), and `setFocusObject` restores it via `check_ready`/`end_ready` on refocus. Normal commit-on-focus-out with no candidate window open is therefore unchanged.

## Verification

e2e suite from #776 (`q01_757_candidate_survives_focus_loss` runtime-skips while this bug exists, so a skip would mean the fix didn't take).

Before (same worktree, fix stashed) — the popup dies and the test skips:

```
running 1 test
test q01_757_candidate_survives_focus_loss ... SKIP q01_757: KNOWN PRODUCT BUG — candidate window (pid 3986358) died after the app lost focus: Qt's focus-out commit() runs reset() before setFocusObject's engine_ready guard (residual #757, PR #771 incomplete). Guard commit() with engine_ready to enable this test.
ok
```

After — q01 runs its assertions to completion, and the rest of the Qt suite stays green:

```
running 4 tests
test q01_757_candidate_survives_focus_loss ... ok
test q02_760_altr_self_modifier_e2e ... ok
test q5_smoke ... SKIP q5_smoke: KNOWN PRODUCT BUG — qt5 plugin metadata IID lacks '.5.1' (KIME_QT_IID define missing from src/frontends/qt5/meson.build); Qt5 loads no kime input context. Fix the meson recipe to enable this test.
ok
test q6_smoke ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 5.00s
```

`q6_smoke` (normal preedit + commit flow) and `q02` staying green is the evidence that the commit guard does not break ordinary commits. `q5_smoke`'s skip is the unrelated qt5 `KIME_QT_IID` meson bug (#778), untouched here.

Fixes #779

https://claude.ai/code/session_0141u6JLkeQSAjAWpCYDia1G