### PR TITLE
fix(qt5): pass the input context IID define to moc and the compiler

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@
 * fix(engine): volume keys (Mute/VolumeDown/VolumeUp) no longer act as Hangul/Hanja keys — hardware keycodes 121/122/123 were raw evdev values added by mistake; only the real X11 keycodes 130 (`<HNGL>`) and 131 (`<HJCV>`) map now [#603](https://github.com/Riey/kime/issues/603) [#769](https://github.com/Riey/kime/pull/769)
 * fix(engine): reap the candidate window process after killing it so dismissed hanja popups no longer accumulate as zombie (`<defunct>`) processes [#617](https://github.com/Riey/kime/issues/617) [#769](https://github.com/Riey/kime/pull/769)
 * fix(engine): log config file open/parse errors instead of silently falling back to the default config, so a syntax error in `config.yaml` is diagnosable [#656](https://github.com/Riey/kime/issues/656) [#769](https://github.com/Riey/kime/pull/769)
+* fix(qt5): pass the input context IID define to moc and the compiler so Qt5 apps load the kime input context again — broken since the meson migration ([#747]) which fixed only qt6 ([#756]) [#778](https://github.com/Riey/kime/issues/778) [#785](https://github.com/Riey/kime/pull/785)
 * feat(engine): layout files support an optional `version:`/`keys:` format — files declaring a format version newer than kime supports are rejected with a clear error instead of breaking silently on a future format change, legacy flat-map layouts keep working unchanged, and user layout files that fail to load are logged with the reason instead of silently skipped [#540](https://github.com/Riey/kime/issues/540) [#774](https://github.com/Riey/kime/pull/774)
 
 ## 3.2.0

--- a/src/frontends/qt5/meson.build
+++ b/src/frontends/qt5/meson.build
@@ -17,6 +17,7 @@ if qt5_dep.found()
   qt5_moc = qt5_mod.preprocess(
     moc_headers: ['src/plugin.hpp', 'src/input_context.hpp'],
     dependencies: [qt5_dep, kime_engine_dep],
+    moc_extra_arguments: ['-DKIME_QT_IID="org.qt-project.Qt.QPlatformInputContextFactoryInterface.5.1"'],
   )
 
   shared_library('kimeplatforminputcontextplugin',
@@ -24,6 +25,7 @@ if qt5_dep.found()
     'src/input_context.cc',
     qt5_moc,
     dependencies: [qt5_dep, kime_engine_dep],
+    cpp_args: ['-DKIME_QT_IID="org.qt-project.Qt.QPlatformInputContextFactoryInterface.5.1"'],
     install: true,
     install_dir: qt5_plugindir / 'platforminputcontexts',
   )


### PR DESCRIPTION
Fixes #778 (part of #777).

## The bug

`src/frontends/qt5/meson.build` never passes `KIME_QT_IID`, so
`src/frontends/qt5/src/plugin.hpp` falls back to its unsuffixed default:

```cpp
#ifndef KIME_QT_IID
#define KIME_QT_IID "org.qt-project.Qt.QPlatformInputContextFactoryInterface"
#endif

  Q_PLUGIN_METADATA(IID KIME_QT_IID FILE "kime.json")
```

Qt 5.15 (like Qt 6) defines
`QPlatformInputContextFactoryInterface_iid` as
`org.qt-project.Qt.QPlatformInputContextFactoryInterface.5.1`, so the
plugin's embedded metadata never matches what
`QPlatformInputContextFactory` looks for. The `.so` is found and loaded,
its metadata is rejected, and Qt5 apps end up with **no** input context —
silently, with no error. Typing `gksrmf` yields a literal `gksrmf`
instead of `한글`.

This is the same bug class as #736/#756, which fixed the qt6 recipe only;
the qt5 side has been broken since the meson migration (#747) replaced the
CMake build, which had used the Qt-provided
`QPlatformInputContextFactoryInterface_iid` symbol directly.

## The fix

Mirror `src/frontends/qt6/meson.build`: pass the versioned IID both to
`moc` (which bakes it into the plugin metadata blob) and to the C++
compiler (`cpp_args`, so the sources agree with the generated moc code).
Both are required — the define only reaches the metadata via `moc`.

## Verification

**1. Plugin metadata now carries the versioned IID.** The IID is stored
character-by-character in moc's CBOR metadata array, so comparing moc
output with and without the define shows the difference directly:

```
=== moc define: <none> ===
QTMETADATA,org.qt-project.Qt.QPlatformInputContextFactoryInterfaceKimePlatformInputContextPluginKeyskime
=== moc define: -DKIME_QT_IID="org.qt-project.Qt.QPlatformInputContextFactoryInterface.5.1" ===
QTMETADATA,org.qt-project.Qt.QPlatformInputContextFactoryInterface.5.1KimePlatformInputContextPluginKeyskime
```

And in the built artifact (Qt 5.15.19, Arch):

```
$ strings build/src/frontends/qt5/libkimeplatforminputcontextplugin.so | grep QPlatformInputContextFactoryInterface
x;org.qt-project.Qt.QPlatformInputContextFactoryInterface.5.1
```

**2. End-to-end.** `qt::q5_smoke` from the kime-e2e suite (#776) drives a
real Qt5 `QLineEdit` on Xvfb through the staged plugin. It runtime-skips
while the IID is broken; with this fix it runs the full body and passes:

```
$ cargo test -p kime-e2e --test qt -- --ignored --test-threads=1
running 4 tests
test q01_757_candidate_survives_focus_loss ... ok
test q02_760_altr_self_modifier_e2e ... ok
test q5_smoke ... ok
test q6_smoke ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 5.52s
```

No SKIP message is printed, and the probe's kept dumps confirm the input
context is actually driving the widget — buffer `한글`, with a real
`QInputMethodEvent` preedit/commit stream:

```
p:ㅎ  p:하  p:한  p:  c:한  p:ㄱ  p:그  p:글  p:  p:  c:글  p:
```

`q6_smoke` still passes, so qt6 is unaffected.

https://claude.ai/code/session_0141u6JLkeQSAjAWpCYDia1G
