### PR TITLE
test(e2e): red tests for the re-entrant reset double commit in the gtk and qt immodules

### DIFF
--- a/tests/e2e/clients/gtk_reset_probe.py
+++ b/tests/e2e/clients/gtk_reset_probe.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""GTK3 re-entrant-reset probe for the kime e2e harness (#562 shape).
+
+Usage: gtk_reset_probe.py <outprefix> [--reset-in-commit]
+
+Gtk.Entry/TextView hide their im-context, so this client creates a
+Gtk.IMMulticontext directly on a plain toplevel Gtk.Window (set_client_window
+on the toplevel's GdkWindow), forwards raw key events with filter_keypress —
+both passes: kime's GTK3 immodule re-queues events with marker bit 1<<25
+(HANDLED_MASK) via gdk_event_put and expects the client to filter them again —
+and appends:
+
+  <out>.commits   one line per "commit" signal:      d<depth>:<text>
+                  (depth = commit-handler nesting; d2+ = re-entrant emission)
+  <out>.preedit   one line per preedit-changed:      p:<preedit>
+  <out>.events    key/handled trace + reset markers
+
+With --reset-in-commit the commit handler calls im.reset() — the pattern of
+kime#562 (Firefox resets the IM context from its commit path). The reset is
+guarded to depth 1: process_input_result clears the engine commit buffer only
+AFTER the signal emission, so an unguarded handler would recurse without bound
+(each nested kime_reset re-reads the still-uncleared commit string).
+Depth-1-only still exposes the bug as exactly one duplicate line.
+
+Prints CONTEXT_ID:<id> (which slave GTK picked — must be "kime") and READY on
+stderr once the window is mapped and the im-context focused.
+"""
+import sys
+
+import gi
+
+gi.require_version('Gtk', '3.0')
+gi.require_version('Gdk', '3.0')
+from gi.repository import Gdk, Gtk
+
+out = sys.argv[1]
+do_reset = '--reset-in-commit' in sys.argv[2:]
+
+
+def log(suffix, line):
+    # Single append per line, matching gtk_probe.py's preedit log convention
+    # (the harness only ever parses whole lines).
+    with open(out + suffix, 'a') as f:
+        f.write(line + '\n')
+
+
+im = Gtk.IMMulticontext()
+depth = 0
+
+
+def on_commit(ctx, text):
+    global depth
+    depth += 1
+    log('.commits', 'd%d:%s' % (depth, text))
+    if do_reset and depth == 1:
+        log('.events', 'reset-call')
+        ctx.reset()
+        log('.events', 'reset-returned')
+    depth -= 1
+
+
+def on_preedit_changed(ctx):
+    s, _attrs, _pos = ctx.get_preedit_string()
+    log('.preedit', 'p:%s' % s)
+
+
+im.connect('commit', on_commit)
+im.connect('preedit-changed', on_preedit_changed)
+
+win = Gtk.Window(title='kimeprobe')
+win.set_default_size(320, 240)
+win.add_events(Gdk.EventMask.KEY_PRESS_MASK | Gdk.EventMask.KEY_RELEASE_MASK)
+
+
+def on_key(_w, event):
+    handled = im.filter_keypress(event)
+    log('.events', 'key:%s code=%d state=0x%x handled=%s' %
+        (Gdk.keyval_name(event.keyval), event.hardware_keycode,
+         int(event.state), handled))
+    return handled
+
+
+win.connect('key-press-event', on_key)
+win.connect('key-release-event', on_key)
+
+
+def on_map(w, _ev):
+    im.set_client_window(w.get_window())
+    im.focus_in()
+    # context id proves which slave GTK picked (must be "kime")
+    sys.stderr.write('CONTEXT_ID:%s\n' % im.get_context_id())
+    sys.stderr.write('READY\n')
+    sys.stderr.flush()
+    return False
+
+
+win.connect('map-event', on_map)
+win.connect('destroy', Gtk.main_quit)
+win.show_all()
+Gtk.main()

--- a/tests/e2e/clients/qt_probe.cpp
+++ b/tests/e2e/clients/qt_probe.cpp
@@ -4,13 +4,22 @@
 // Usage: qt_probe <outfile>
 //   <outfile>          line-edit text, rewritten every 150ms
 //   <outfile>.preedit  appended "p:<preedit>" / "c:<commit>" per QInputMethodEvent
+//   <outfile>.commits  appended "d<depth>:<commit>" per non-empty commitString,
+//                      only with KIME_PROBE_RESET_IN_COMMIT=1 (see below)
 // Prints READY on stderr once the window is shown.
 //
 // The event filter makes preedit observable (QLineEdit::text() only shows
 // committed text), which the candidate-window (#757) and plugin-loading
 // (#736/#756) tests rely on.
+//
+// With env KIME_PROBE_RESET_IN_COMMIT=1 the line edit's inputMethodEvent
+// override calls QGuiApplication::inputMethod()->reset() upon a commit — the
+// #562-class pattern (a client resets the IM context from its commit path),
+// the qt twin of gtk_reset_probe.py --reset-in-commit. Without the env var
+// the override is pass-through and the probe behaves as before.
 #include <QApplication>
 #include <QFile>
+#include <QInputMethod>
 #include <QInputMethodEvent>
 #include <QLineEdit>
 #include <QTimer>
@@ -39,6 +48,54 @@ private:
     QString m_path;
 };
 
+// Reset-in-commit instrument (#562-class, Q-06/Q-07): with
+// KIME_PROBE_RESET_IN_COMMIT=1 every non-empty commitString is appended to
+// <outfile>.commits as "d<depth>:<text>" (depth = inputMethodEvent nesting;
+// d2+ = the commit was re-delivered from inside the outer delivery), and at
+// depth 1 only the handler calls QGuiApplication::inputMethod()->reset()
+// BEFORE letting QLineEdit process the event. kime's input context emits
+// commits with the synchronous QCoreApplication::sendEvent, so the reset
+// re-enters KimeInputContext::reset() while the outer emission is on the
+// stack. Depth-1-only mirrors gtk_reset_probe.py: pre-fix the engine commit
+// buffer is cleared only after the emission, so an always-resetting client
+// would recurse without bound; capping at depth 1 shows the bug as exactly
+// one duplicate line. Without the env var this class behaves exactly like
+// QLineEdit.
+class ProbeLineEdit : public QLineEdit {
+public:
+    ProbeLineEdit(const QString &commitsPath, bool resetInCommit)
+        : m_commitsPath(commitsPath), m_resetInCommit(resetInCommit) {}
+
+protected:
+    void inputMethodEvent(QInputMethodEvent *ev) override {
+        if (!m_resetInCommit || ev->commitString().isEmpty()) {
+            QLineEdit::inputMethodEvent(ev);
+            return;
+        }
+        ++m_depth;
+        {
+            // Scoped so the append flushes BEFORE the nested reset() below —
+            // an open QFile buffers, and the nested depth-2 line would land
+            // in the log first.
+            QFile f(m_commitsPath);
+            if (f.open(QIODevice::Append)) {
+                f.write("d" + QByteArray::number(m_depth) + ":" +
+                        ev->commitString().toUtf8() + "\n");
+            }
+        }
+        if (m_depth == 1) {
+            QGuiApplication::inputMethod()->reset();
+        }
+        QLineEdit::inputMethodEvent(ev);
+        --m_depth;
+    }
+
+private:
+    QString m_commitsPath;
+    bool m_resetInCommit;
+    int m_depth = 0;
+};
+
 int main(int argc, char **argv) {
     QApplication a(argc, argv);
     if (argc < 2) {
@@ -46,7 +103,8 @@ int main(int argc, char **argv) {
         return 1;
     }
     QString out = QString::fromLocal8Bit(argv[1]);
-    QLineEdit e;
+    ProbeLineEdit e(out + ".commits",
+                    qgetenv("KIME_PROBE_RESET_IN_COMMIT") == "1");
     e.setWindowTitle("kimeprobe");
     e.resize(320, 60);
     ImLogger logger(out + ".preedit");

--- a/tests/e2e/src/cc.rs
+++ b/tests/e2e/src/cc.rs
@@ -16,6 +16,11 @@ pub fn gtk_probe_py() -> PathBuf {
     paths::clients_dir().join("gtk_probe.py")
 }
 
+/// Path of the `gtk_reset_probe.py` script (no compilation needed).
+pub fn gtk_reset_probe_py() -> PathBuf {
+    paths::clients_dir().join("gtk_reset_probe.py")
+}
+
 /// Build the XIM client (`xim_client <outfile>`).
 pub fn xim_client() -> Result<PathBuf> {
     let src = paths::clients_dir().join("xim_client.c");

--- a/tests/e2e/src/probes.rs
+++ b/tests/e2e/src/probes.rs
@@ -187,6 +187,85 @@ fn spawn_gtk_common(
     })
 }
 
+/// A spawned `gtk_reset_probe.py` client: a direct `Gtk.IMMulticontext` (no
+/// Entry/TextView) that logs every "commit" signal with its handler nesting
+/// depth — the instrument for the #562 re-entrant-reset tests.
+pub struct GtkResetProbe {
+    /// `.commits` log: one `d<depth>:<text>` line per "commit" signal
+    /// (read with [`GtkResetProbe::commit_lines`]; `d2:`+ = re-entrant).
+    pub commits_log: PathBuf,
+    /// `.preedit` log path (parse with [`read_im_log`]).
+    pub preedit_log: PathBuf,
+    /// `.events` trace (key forwarding + reset markers).
+    pub events_log: PathBuf,
+    /// Probe stderr log.
+    pub log: PathBuf,
+    proc: Proc,
+}
+
+impl GtkResetProbe {
+    pub fn pid(&self) -> i32 {
+        self.proc.pid()
+    }
+
+    pub fn alive(&mut self) -> bool {
+        self.proc.alive()
+    }
+
+    /// All `d<depth>:<text>` lines committed so far (missing file = none yet).
+    pub fn commit_lines(&self) -> Vec<String> {
+        let Ok(bytes) = std::fs::read(&self.commits_log) else {
+            return Vec::new();
+        };
+        String::from_utf8_lossy(&bytes)
+            .lines()
+            .map(str::to_string)
+            .collect()
+    }
+}
+
+/// GTK3 re-entrant-reset probe on a harness X display with staged-immodule
+/// env. `reset_in_commit` passes `--reset-in-commit` (the client calls
+/// `im.reset()` from its commit handler — the kime#562 Firefox pattern).
+/// Waits for `READY` and verifies the IMMulticontext picked the `kime` slave;
+/// callers still need [`XvfbSession::focus_window`]`(`[`PROBE_TITLE`]`)`.
+pub fn spawn_gtk_reset_probe_x11(
+    x: &XvfbSession,
+    extra_env: &[(String, String)],
+    reset_in_commit: bool,
+    scratch: &ScratchDir,
+) -> Result<GtkResetProbe> {
+    let out = scratch.file("gtk3-reset");
+    let log = scratch.file("gtk3-reset-probe.log");
+    let logfile =
+        std::fs::File::create(&log).map_err(|e| format!("cannot create {}: {e}", log.display()))?;
+    let mut cmd = clean_cmd("python3");
+    cmd.env("DISPLAY", x.display())
+        .env("GDK_BACKEND", "x11")
+        .env("LD_LIBRARY_PATH", envs::ld_library_path());
+    for (k, v) in extra_env {
+        cmd.env(k, v);
+    }
+    cmd.arg(cc::gtk_reset_probe_py()).arg(&out);
+    if reset_in_commit {
+        cmd.arg("--reset-in-commit");
+    }
+    cmd.stdout(Stdio::null()).stderr(logfile);
+    let mut proc = Proc::spawn(&mut cmd, "gtk3-reset-probe")?;
+    proc.wait_ready_line(&log, &["READY"], Duration::from_secs(15))?;
+    // The probe prints CONTEXT_ID before READY; anything but "kime" means GTK
+    // silently fell back to another slave and the test would be vacuous.
+    proc::wait_for_line(&log, &["CONTEXT_ID:kime"], Duration::from_secs(1))
+        .map_err(|e| format!("IMMulticontext slave is not kime: {e}"))?;
+    Ok(GtkResetProbe {
+        commits_log: out.with_extension("commits"),
+        preedit_log: out.with_extension("preedit"),
+        events_log: out.with_extension("events"),
+        log,
+        proc,
+    })
+}
+
 /// Qt probe (QLineEdit) on a harness X display with staged plugin env.
 pub fn spawn_qt_probe_x11(
     x: &XvfbSession,

--- a/tests/e2e/tests/gtk3.rs
+++ b/tests/e2e/tests/gtk3.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 use kime_e2e::kime;
 use kime_e2e::paths::{self, ScratchDir};
-use kime_e2e::probes::{self, GtkProbeOpts, GuiProbe, ImEvent, PROBE_TITLE};
+use kime_e2e::probes::{self, GtkProbeOpts, GtkResetProbe, GuiProbe, ImEvent, PROBE_TITLE};
 use kime_e2e::proc;
 use kime_e2e::stage::{self, Staged};
 use kime_e2e::x11::XvfbSession;
@@ -337,4 +337,98 @@ fn g3_02b_780_global_hotkey_closes_candidate() {
         .buffer
         .wait_contains("d", WAIT)
         .expect("Esc did not switch the category to Latin (expected a literal 'd')");
+}
+
+/// Stage the local GTK3 immodule, write a Hangul config, and spawn the
+/// re-entrant-reset probe (a direct `Gtk.IMMulticontext` — Entry/TextView
+/// hide theirs). The caller must still `focus_window(PROBE_TITLE)` before
+/// typing.
+fn spawn_reset_probe(
+    x: &XvfbSession,
+    scratch: &ScratchDir,
+    reset_in_commit: bool,
+) -> (GtkResetProbe, Staged) {
+    let staged = stage::stage_gtk3(scratch).expect("stage gtk3 immodule");
+    let xdg = kime::write_config(scratch, kime::HANGUL_CONFIG).expect("write kime config");
+    let mut env = staged.env.clone();
+    env.push(("XDG_CONFIG_HOME".into(), xdg.display().to_string()));
+    let probe = probes::spawn_gtk_reset_probe_x11(x, &env, reset_in_commit, scratch)
+        .expect("start gtk3 reset probe");
+    (probe, staged)
+}
+
+/// Wait until the reset probe logged a commit line containing `한`, then let
+/// the event loop settle: the duplicate (if any) is emitted synchronously by
+/// the nested handler, but the GTK3 immodule also re-queues the event
+/// (HANDLED_MASK pass), so give any straggler time to land before reading.
+fn wait_commits_settled(probe: &GtkResetProbe) -> Vec<String> {
+    proc::wait_until(
+        &format!(
+            "a 한 commit line in {} (lines: {:?})",
+            probe.commits_log.display(),
+            probe.commit_lines()
+        ),
+        WAIT,
+        || probe.commit_lines().iter().any(|l| l.contains("한")),
+    )
+    .expect("no commit ever arrived");
+    proc::sleep_ms(500);
+    probe.commit_lines()
+}
+
+/// G3-06 (guards the probe for G3-07): with a do-nothing commit handler,
+/// `gks` + Return through the staged immodule delivers exactly ONE `한`
+/// commit at depth 1. If this fails, the probe/staging is broken and G3-07
+/// proves nothing.
+#[test]
+#[ignore = "e2e: spawns Xvfb and a GTK3 app; run with --ignored"]
+fn g3_06_reset_in_commit_baseline() {
+    let scratch = ScratchDir::new("g3_06_reset_base");
+    let x = XvfbSession::new(&scratch).expect("start Xvfb");
+    let (probe, staged) = spawn_reset_probe(&x, &scratch, false);
+    x.focus_window(PROBE_TITLE).expect("focus probe window");
+
+    x.type_text("gks").expect("type gks");
+    x.key("Return").expect("press Return");
+
+    let lines = wait_commits_settled(&probe);
+    stage::maps_check_staged(probe.pid(), &staged).expect("local gtk3 immodule loaded");
+    assert!(
+        lines == ["d1:한"],
+        "baseline: one keypress must commit 한 exactly once at depth 1;\n.commits was: {lines:?}"
+    );
+}
+
+/// G3-07 (#562; guard added by #563, removed by #570 — RED until fixed):
+/// a client calling `gtk_im_context_reset()` from inside its "commit"
+/// handler receives the SAME text twice.
+///
+/// `process_input_result` (src/frontends/gtk3/src/immodule.c) emits the
+/// commit signal BEFORE `kime_engine_clear_commit`, and `reset` →
+/// `kime_reset` is unguarded: the handler's `reset()` re-enters, re-reads
+/// the still-uncleared engine commit buffer, and emits `한` again from the
+/// nested emission (`d2:한`). That is the kime#562 Firefox pattern (reset
+/// from the commit path); #563 fixed it with an `is_committing` guard and
+/// #570 (753b106) dropped the guard. A client that resets on EVERY commit
+/// recurses without bound — the probe caps its reset at depth 1, so the bug
+/// shows as exactly one duplicate.
+#[test]
+#[ignore = "e2e: spawns Xvfb and a GTK3 app; run with --ignored"]
+fn g3_07_562_reset_in_commit_double() {
+    let scratch = ScratchDir::new("g3_07_562");
+    let x = XvfbSession::new(&scratch).expect("start Xvfb");
+    let (probe, staged) = spawn_reset_probe(&x, &scratch, true);
+    x.focus_window(PROBE_TITLE).expect("focus probe window");
+
+    x.type_text("gks").expect("type gks");
+    x.key("Return").expect("press Return");
+
+    let lines = wait_commits_settled(&probe);
+    stage::maps_check_staged(probe.pid(), &staged).expect("local gtk3 immodule loaded");
+    assert!(
+        lines == ["d1:한"],
+        "#562 regression: reset() inside the commit handler re-delivered the \
+         commit (immodule.c emits before kime_engine_clear_commit and \
+         kime_reset is unguarded since #570);\n.commits was: {lines:?}"
+    );
 }

--- a/tests/e2e/tests/qt.rs
+++ b/tests/e2e/tests/qt.rs
@@ -249,6 +249,115 @@ fn q01_757_candidate_survives_focus_loss() {
     }
 }
 
+/// `d<depth>:<text>` lines from the qt probe's `.commits` log (written by its
+/// `KIME_PROBE_RESET_IN_COMMIT` inputMethodEvent override; missing file =
+/// none yet).
+fn commit_depth_lines(probe: &kime_e2e::probes::GuiProbe) -> Vec<String> {
+    let path = probe.buffer.path().with_extension("txt.commits");
+    let Ok(bytes) = std::fs::read(path) else {
+        return Vec::new();
+    };
+    String::from_utf8_lossy(&bytes)
+        .lines()
+        .map(str::to_string)
+        .collect()
+}
+
+/// Shared Q-06/Q-07 body: Xvfb + staged qt6 plugin + the probe (with the
+/// reset-in-commit override when asked), type `gks` + Return, wait for a 한
+/// commit `QInputMethodEvent`, then let the event loop settle — the
+/// re-entrant duplicate (if any) arrives synchronously inside the outer
+/// delivery, but give any straggler time to land before reading. Returns
+/// (IM events, `.commits` depth lines).
+fn qt_reset_round(scratch_name: &str, reset_in_commit: bool) -> (Vec<ImEvent>, Vec<String>) {
+    let scratch = ScratchDir::new(scratch_name);
+    let x = XvfbSession::new(&scratch).expect("start Xvfb");
+    let xdg = kime::write_config(&scratch, kime::HANGUL_CONFIG).expect("write kime config");
+    let staged = stage::stage_qt(&scratch, 6).expect("stage qt6 plugin");
+    let mut env = staged.env.clone();
+    env.push(("XDG_CONFIG_HOME".into(), xdg.display().to_string()));
+    if reset_in_commit {
+        env.push(("KIME_PROBE_RESET_IN_COMMIT".into(), "1".into()));
+    }
+    let mut probe = probes::spawn_qt_probe_x11(&x, 6, &env, &scratch).expect("start qt6 probe");
+    stage::maps_check_staged(probe.pid(), &staged).expect("staged kime plugin loaded");
+    x.focus_window(probes::PROBE_TITLE).expect("focus probe");
+
+    x.type_text("gks").expect("type gks");
+    x.key("Return").expect("press Return");
+
+    proc::wait_until(
+        &format!(
+            "a 한 commit event in {} (events: {:?})",
+            probe.preedit_log.display(),
+            probes::read_im_log(&probe.preedit_log)
+        ),
+        Duration::from_secs(10),
+        || {
+            probes::read_im_log(&probe.preedit_log)
+                .iter()
+                .any(|e| matches!(e, ImEvent::Commit(c) if c.contains("한")))
+        },
+    )
+    .expect("no commit ever arrived");
+    proc::sleep_ms(500);
+    assert!(probe.alive(), "qt6 probe died during the test");
+    let events = probes::read_im_log(&probe.preedit_log);
+    let depth_lines = commit_depth_lines(&probe);
+    (events, depth_lines)
+}
+
+/// Q-06 (guards the probe for Q-07): with the reset-in-commit override
+/// disabled, `gks` + Return through the staged qt6 plugin delivers exactly
+/// ONE 한 commit `QInputMethodEvent`. If this fails, the probe/staging is
+/// broken and Q-07 proves nothing.
+#[test]
+#[ignore = "e2e: spawns Xvfb and a Qt6 GUI probe; run with --ignored"]
+fn q06_reset_in_commit_baseline() {
+    let (events, depth_lines) = qt_reset_round("q06_reset_base", false);
+    let commits: Vec<String> = events
+        .iter()
+        .filter_map(|e| match e {
+            ImEvent::Commit(c) => Some(c.clone()),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        commits == ["한"],
+        "baseline: one keypress must commit 한 exactly once;\ncommits: {commits:?}\nevents: {events:?}"
+    );
+    assert!(
+        depth_lines.is_empty(),
+        "normal mode must not write the .commits log (probe mode leaked);\ngot: {depth_lines:?}"
+    );
+}
+
+/// Q-07 (#562-class — the qt twin of G3-07): a client whose
+/// `inputMethodEvent()` calls `QGuiApplication::inputMethod()->reset()` upon
+/// a commit receives the SAME text twice.
+///
+/// `process_input_result` (src/frontends/qt5/src/input_context.cc, shared by
+/// the qt5 and qt6 builds) emits the commit via the SYNCHRONOUS
+/// `QCoreApplication::sendEvent` BEFORE `kime_engine_clear_commit`, and
+/// `reset()` is unguarded (`clear_preedit` → `commit_str(emit)` →
+/// `kime_engine_reset`): the widget's reset re-enters while the outer
+/// sendEvent is still on the stack, re-reads the still-uncleared engine
+/// commit buffer, and delivers 한 again (`d2:한`). The probe caps its reset
+/// at depth 1 — an always-resetting client would recurse without bound — so
+/// the bug shows as exactly one duplicate line.
+#[test]
+#[ignore = "e2e: spawns Xvfb and a Qt6 GUI probe; run with --ignored"]
+fn q07_reset_in_commit_double() {
+    let (events, depth_lines) = qt_reset_round("q07_reset_double", true);
+    assert!(
+        depth_lines == ["d1:한"],
+        "#562-class regression: reset() inside inputMethodEvent re-delivered \
+         the commit (input_context.cc emits via sendEvent before \
+         kime_engine_clear_commit and reset() is unguarded);\n.commits was: \
+         {depth_lines:?}\nevents: {events:?}"
+    );
+}
+
 /// True when the Qt6 wayland platform plugin appears to be installed. When the
 /// platforms dir is missing entirely we optimistically return true and let the
 /// probe spawn decide.


### PR DESCRIPTION
Red-until-fixed guard for #797. The `e2e` job on this PR FAILS by design — that failure is the bug demonstration; the fix PR stacked on this branch turns it green.

Four tests (all `#[ignore]`, run by the e2e job):

- `g3_06_reset_in_commit_baseline` / `g3_07_562_reset_in_commit_double` — a direct `Gtk.IMMulticontext` client (`clients/gtk_reset_probe.py`: forwards both key passes incl. kime's re-queued `HANDLED_MASK` events, logs every commit-signal payload as `d<depth>:<text>`, and in `--reset-in-commit` mode calls `im.reset()` from the commit handler at depth 1). Baseline asserts exactly one `한` for `gks`+Return; the double test asserts the same and currently gets `["d1:한", "d2:한"]`. A `CONTEXT_ID:kime` gate makes a silent fallback to another GTK module an error instead of a vacuous pass.
- `q06_reset_in_commit_baseline` / `q07_reset_in_commit_double` — Qt6 twin via `qt_probe.cpp` (`KIME_PROBE_RESET_IN_COMMIT=1` makes the probe's line edit call `QGuiApplication::inputMethod()->reset()` from `inputMethodEvent`). Same assertion, currently the same `d1:한`+`d2:한` failure — the `sendEvent` delivery is synchronous, so the re-entry is real on Qt too.

gtk4 twin skipped: GTK4's controller-based key delivery gives pygobject no clean way to feed raw events to `filter_keypress`, and the vulnerable code is compiled verbatim into the gtk4 module from the same `immodule.c`, so the gtk3 test pins the shared defect.

https://claude.ai/code/session_0141u6JLkeQSAjAWpCYDia1G